### PR TITLE
Check also the performance and see if we should do the same for className

### DIFF
--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/util/CommerceAccountRoleHelperImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/util/CommerceAccountRoleHelperImpl.java
@@ -20,6 +20,7 @@ import com.liferay.commerce.pricing.constants.CommercePricingPortletKeys;
 import com.liferay.commerce.product.constants.CPActionKeys;
 import com.liferay.commerce.product.constants.CPPortletKeys;
 import com.liferay.commerce.util.CommerceAccountRoleHelper;
+import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -118,8 +119,14 @@ public class CommerceAccountRoleHelperImpl
 		throws PortalException {
 
 		for (Map.Entry<String, String[]> entry : resourceActionIds.entrySet()) {
-			_resourceActionLocalService.checkResourceActions(
-				entry.getKey(), Arrays.asList(entry.getValue()));
+			try {
+				DBPartitionUtil.forEachCompanyId(
+					company -> _resourceActionLocalService.checkResourceActions(
+						entry.getKey(), Arrays.asList(entry.getValue())));
+			}
+			catch (Exception exception) {
+				throw new PortalException(exception);
+			}
 
 			for (String actionId : entry.getValue()) {
 				_resourcePermissionLocalService.addResourcePermission(

--- a/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
@@ -45,16 +45,26 @@ public class StartupHelperUtil {
 
 	public static void initResourceActions() {
 		if (_dbNew) {
-			_initResourceActions();
+			ResourceActionLocalServiceUtil.checkResourceActions();
 		}
 		else {
 			try {
 				DBPartitionUtil.forEachCompanyId(
-					companyId -> _initResourceActions());
+					companyId ->
+						ResourceActionLocalServiceUtil.checkResourceActions());
 			}
 			catch (Exception exception) {
 				ReflectionUtil.throwException(exception);
 			}
+		}
+
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			ResourceActionsUtil.populateModelResources(
+				StartupHelperUtil.class.getClassLoader(),
+				PropsValues.RESOURCE_ACTIONS_CONFIGS);
+		}
+		catch (ResourceActionsException resourceActionsException) {
+			ReflectionUtil.throwException(resourceActionsException);
 		}
 	}
 
@@ -174,19 +184,6 @@ public class StartupHelperUtil {
 			System.out.println(msg);
 
 			throw new RuntimeException(msg);
-		}
-	}
-
-	private static void _initResourceActions() {
-		ResourceActionLocalServiceUtil.checkResourceActions();
-
-		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			ResourceActionsUtil.populateModelResources(
-				StartupHelperUtil.class.getClassLoader(),
-				PropsValues.RESOURCE_ACTIONS_CONFIGS);
-		}
-		catch (ResourceActionsException resourceActionsException) {
-			ReflectionUtil.throwException(resourceActionsException);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
@@ -44,18 +44,13 @@ import java.util.List;
 public class StartupHelperUtil {
 
 	public static void initResourceActions() {
-		if (_dbNew) {
-			ResourceActionLocalServiceUtil.checkResourceActions();
+		try {
+			DBPartitionUtil.forEachCompanyId(
+				companyId ->
+					ResourceActionLocalServiceUtil.checkResourceActions());
 		}
-		else {
-			try {
-				DBPartitionUtil.forEachCompanyId(
-					companyId ->
-						ResourceActionLocalServiceUtil.checkResourceActions());
-			}
-			catch (Exception exception) {
-				ReflectionUtil.throwException(exception);
-			}
+		catch (Exception exception) {
+			ReflectionUtil.throwException(exception);
 		}
 
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {

--- a/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
@@ -7,6 +7,7 @@ package com.liferay.portal.events;
 
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.exception.ResourceActionsException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -43,15 +44,17 @@ import java.util.List;
 public class StartupHelperUtil {
 
 	public static void initResourceActions() {
-		ResourceActionLocalServiceUtil.checkResourceActions();
-
-		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			ResourceActionsUtil.populateModelResources(
-				StartupHelperUtil.class.getClassLoader(),
-				PropsValues.RESOURCE_ACTIONS_CONFIGS);
+		if (_dbNew) {
+			_initResourceActions();
 		}
-		catch (ResourceActionsException resourceActionsException) {
-			ReflectionUtil.throwException(resourceActionsException);
+		else {
+			try {
+				DBPartitionUtil.forEachCompanyId(
+					companyId -> _initResourceActions());
+			}
+			catch (Exception exception) {
+				ReflectionUtil.throwException(exception);
+			}
 		}
 	}
 
@@ -171,6 +174,19 @@ public class StartupHelperUtil {
 			System.out.println(msg);
 
 			throw new RuntimeException(msg);
+		}
+	}
+
+	private static void _initResourceActions() {
+		ResourceActionLocalServiceUtil.checkResourceActions();
+
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			ResourceActionsUtil.populateModelResources(
+				StartupHelperUtil.class.getClassLoader(),
+				PropsValues.RESOURCE_ACTIONS_CONFIGS);
+		}
+		catch (ResourceActionsException resourceActionsException) {
+			ReflectionUtil.throwException(resourceActionsException);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
@@ -45,9 +45,7 @@ public class StartupHelperUtil {
 
 	public static void initResourceActions() {
 		try {
-			DBPartitionUtil.forEachCompanyId(
-				companyId ->
-					ResourceActionLocalServiceUtil.checkResourceActions());
+			ResourceActionLocalServiceUtil.checkResourceActions();
 		}
 		catch (Exception exception) {
 			ReflectionUtil.throwException(exception);

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -11,6 +11,8 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.db.partition.DBPartitionUtil;
+import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.exception.ResourceActionsException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -455,9 +457,9 @@ public class ResourceActionsImpl implements ResourceActions {
 
 		if (checkResourceActions) {
 			for (String modelResourceName : modelResourceNames) {
-				resourceActionLocalService.checkResourceActions(
-					modelResourceName,
-					getModelResourceActions(modelResourceName));
+				_checkResourceActions(
+					getModelResourceActions(modelResourceName),
+					modelResourceName);
 			}
 		}
 	}
@@ -483,8 +485,8 @@ public class ResourceActionsImpl implements ResourceActions {
 		_readModelResources(document.getRootElement(), modelResourceNames);
 
 		for (String modelResourceName : modelResourceNames) {
-			resourceActionLocalService.checkResourceActions(
-				modelResourceName, getModelResourceActions(modelResourceName));
+			_checkResourceActions(
+				getModelResourceActions(modelResourceName), modelResourceName);
 		}
 	}
 
@@ -502,9 +504,9 @@ public class ResourceActionsImpl implements ResourceActions {
 		String portletResourceName = PortletIdCodec.decodePortletName(
 			portlet.getPortletId());
 
-		resourceActionLocalService.checkResourceActions(
-			portletResourceName,
-			_getPortletResourceActions(portletResourceName, portlet));
+		_checkResourceActions(
+			_getPortletResourceActions(portletResourceName, portlet),
+			portletResourceName);
 	}
 
 	@Override
@@ -529,9 +531,9 @@ public class ResourceActionsImpl implements ResourceActions {
 		String portletResourceName = PortletIdCodec.decodePortletName(
 			portlet.getPortletId());
 
-		resourceActionLocalService.checkResourceActions(
-			portletResourceName,
-			_getPortletResourceActions(portletResourceName, portlet));
+		_checkResourceActions(
+			_getPortletResourceActions(portletResourceName, portlet),
+			portletResourceName);
 	}
 
 	@Override
@@ -565,9 +567,9 @@ public class ResourceActionsImpl implements ResourceActions {
 
 		if (checkResourceActions) {
 			for (String portletResourceName : portletResourceNames) {
-				resourceActionLocalService.checkResourceActions(
-					portletResourceName,
-					getPortletResourceActions(portletResourceName));
+				_checkResourceActions(
+					getPortletResourceActions(portletResourceName),
+					portletResourceName);
 			}
 		}
 	}
@@ -612,12 +614,22 @@ public class ResourceActionsImpl implements ResourceActions {
 	private void _check(
 		String portletName, List<String> portletResourceActions) {
 
-		ResourceActionLocalServiceUtil.checkResourceActions(
-			portletName, portletResourceActions);
+		try {
+			DBPartitionUtil.forEachCompanyId(
+				companyId -> {
+					ResourceActionLocalServiceUtil.checkResourceActions(
+						portletName, portletResourceActions);
 
-		for (String modelName : getPortletModelResources(portletName)) {
-			ResourceActionLocalServiceUtil.checkResourceActions(
-				modelName, getModelResourceActions(modelName));
+					for (String modelName :
+							getPortletModelResources(portletName)) {
+
+						ResourceActionLocalServiceUtil.checkResourceActions(
+							modelName, getModelResourceActions(modelName));
+					}
+				});
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
 		}
 	}
 
@@ -651,6 +663,23 @@ public class ResourceActionsImpl implements ResourceActions {
 		actions.add(ActionKeys.PERMISSIONS);
 		actions.add(ActionKeys.PREFERENCES);
 		actions.add(ActionKeys.VIEW);
+	}
+
+	private void _checkResourceActions(List<String> actionIds, String name) {
+		if (StartupHelperUtil.isDBNew()) {
+			resourceActionLocalService.checkResourceActions(name, actionIds);
+		}
+		else {
+			try {
+				DBPartitionUtil.forEachCompanyId(
+					companyId ->
+						resourceActionLocalService.checkResourceActions(
+							name, actionIds));
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
 	}
 
 	private String _getCompositeModelName(Element compositeModelNameElement) {

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -81,6 +81,7 @@ import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.PasswordPolicyLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
@@ -266,6 +267,10 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			if (webId.equals("liferay.net")) {
 				_addDemoSettings(company);
 			}
+
+			// Check ResourceActions
+
+			_resourceActionLocalService.checkResourceActions();
 
 			company = _checkCompany(company);
 
@@ -2179,6 +2184,9 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 	private PortletPersistence _portletPersistence;
 
 	private final Set<Company> _preregisterPendingCompanies = new HashSet<>();
+
+	@BeanReference(type = ResourceActionLocalService.class)
+	private ResourceActionLocalService _resourceActionLocalService;
 
 	@BeanReference(type = RoleLocalService.class)
 	private RoleLocalService _roleLocalService;

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -270,7 +270,9 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 			// Check ResourceActions
 
-			_resourceActionLocalService.checkResourceActions();
+			if (DBPartition.isPartitionEnabled()) {
+				_resourceActionLocalService.checkResourceActions();
+			}
 
 			company = _checkCompany(company);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -268,12 +268,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				_addDemoSettings(company);
 			}
 
-			// Check ResourceActions
-
-			if (DBPartition.isPartitionEnabled()) {
-				_resourceActionLocalService.checkResourceActions();
-			}
-
 			company = _checkCompany(company);
 
 			_userLocalService.addDefaultAdminUser(
@@ -1934,6 +1928,12 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		try {
 			preregisterCompany(company);
+
+			// Check ResourceActions
+
+			if (DBPartition.isPartitionEnabled()) {
+				_resourceActionLocalService.checkResourceActions();
+			}
 
 			Locale companyDefaultLocale = LocaleUtil.fromLanguageId(
 				PropsValues.COMPANY_DEFAULT_LOCALE);

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourceActionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourceActionLocalServiceImpl.java
@@ -7,10 +7,12 @@ package com.liferay.portal.service.impl;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.NoSuchResourceActionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -338,7 +340,14 @@ public class ResourceActionLocalServiceImpl
 	}
 
 	protected String encodeKey(String name, String actionId) {
-		return StringBundler.concat(name, StringPool.POUND, actionId);
+		String key = StringBundler.concat(name, StringPool.POUND, actionId);
+
+		if (DBPartition.isPartitionEnabled()) {
+			return StringBundler.concat(
+				key, StringPool.AT, DBPartitionUtil.getCurrentCompanyId());
+		}
+
+		return key;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -343,17 +343,19 @@ public class DBUpgrader {
 
 		try {
 			DBPartitionUtil.forEachCompanyId(
-				companyId -> ClassNameLocalServiceUtil.checkClassNames());
+				companyId -> {
+					ClassNameLocalServiceUtil.checkClassNames();
+
+					if (_log.isDebugEnabled()) {
+						_log.debug("Check resource actions");
+					}
+
+					StartupHelperUtil.initResourceActions();
+				});
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);
 		}
-
-		if (_log.isDebugEnabled()) {
-			_log.debug("Check resource actions");
-		}
-
-		StartupHelperUtil.initResourceActions();
 	}
 
 	private static int _getBuildNumber() throws Exception {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -322,6 +322,10 @@ public class PortalUpgradeProcessRegistryImpl
 			new UpgradePartitionedControlTable("ClassName_"),
 			UpgradeModulesFactory.create(
 				new String[] {"com.liferay.comment.web"}, null));
+
+		upgradeVersionTreeMap.put(
+			new Version(28, 0, 0),
+			new UpgradePartitionedControlTable("ResourceAction"));
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -428,7 +428,7 @@ public class DBInspector {
 	private static final Set<String> _controlTableNames = new HashSet<>(
 		Arrays.asList("company", "virtualhost"));
 	private static final Set<String> _partitionedControlTableNames =
-		new HashSet<>(Arrays.asList("classname_"));
+		new HashSet<>(Arrays.asList("classname_", "resourceaction"));
 
 	private final Connection _connection;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/db/partition/DBPartition.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/partition/DBPartition.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.kernel.db.partition;
 
 import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
@@ -19,7 +20,8 @@ public class DBPartition {
 	public static boolean isPartitionedModel(Class<?> clazz) {
 		if (isPartitionEnabled() &&
 			(ClassName.class.isAssignableFrom(clazz) ||
-			 ShardedModel.class.isAssignableFrom(clazz))) {
+			 ShardedModel.class.isAssignableFrom(clazz) ||
+			 ResourceAction.class.isAssignableFrom(clazz))) {
 
 			return true;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/db/partition/DBPartition.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/partition/DBPartition.java
@@ -20,8 +20,8 @@ public class DBPartition {
 	public static boolean isPartitionedModel(Class<?> clazz) {
 		if (isPartitionEnabled() &&
 			(ClassName.class.isAssignableFrom(clazz) ||
-			 ShardedModel.class.isAssignableFrom(clazz) ||
-			 ResourceAction.class.isAssignableFrom(clazz))) {
+			 ResourceAction.class.isAssignableFrom(clazz) ||
+			 ShardedModel.class.isAssignableFrom(clazz))) {
 
 			return true;
 		}


### PR DESCRIPTION
- LPS-193234 Modify the key to support partitioned ResourceActions
- LPS-193234 Mark ResourceAction as a partitioned control table
- LPS-193234 ResourceAction must be considered a sharded model even when does not have companyId
- LPS-193234 It is needed to checkResourcesActions when adding a new company as it caches the registries
- LPS-193234 Check ResourceActions for every partition
- LPS-193234 Add upgrade process
- LPS-193234 It is not needed to call populateModelResources inside a forEachCompanyId beacuse internally it already runs on all the companies
- LPS-193234 Proper order
- LPS-193234 This is not needed because without DB Partitioning we already call it in the forEachCompany and with DBPartitioning is called in the addCompany method
- LPS-193234 Not needed without DB Partition enabled
- Draft clustering issue
