### PR TITLE
LPD 42705 4

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -690,13 +690,13 @@ public class ObjectDefinitionLocalServiceImpl
 
 		for (Map.Entry
 				<InactiveObjectDefinitionDeployer,
-				 Map<Long, List<ServiceRegistration<?>>>> entry :
+				 Map<String, List<ServiceRegistration<?>>>> entry :
 					_inactiveObjectDefinitionsServiceRegistrationsMaps.
 						entrySet()) {
 
 			InactiveObjectDefinitionDeployer inactiveObjectDefinitionDeployer =
 				entry.getKey();
-			Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+			Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 				entry.getValue();
 
 			try (SafeCloseable safeCloseable =
@@ -704,7 +704,8 @@ public class ObjectDefinitionLocalServiceImpl
 						objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					objectDefinition.getObjectDefinitionId(),
+					objectDefinition.getCompanyId() + StringPool.AT +
+						objectDefinition.getObjectDefinitionId(),
 					objectDefinitionId ->
 						inactiveObjectDefinitionDeployer.deploy(
 							objectDefinition));
@@ -718,18 +719,19 @@ public class ObjectDefinitionLocalServiceImpl
 
 		for (Map.Entry
 				<ObjectDefinitionDeployer,
-				 Map<Long, List<ServiceRegistration<?>>>> entry :
+				 Map<String, List<ServiceRegistration<?>>>> entry :
 					_serviceRegistrationsMaps.entrySet()) {
 
 			ObjectDefinitionDeployer objectDefinitionDeployer = entry.getKey();
-			Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+			Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 				entry.getValue();
 
 			try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
 					objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					objectDefinition.getObjectDefinitionId(),
+					objectDefinition.getCompanyId() + StringPool.AT +
+						objectDefinition.getObjectDefinitionId(),
 					objectDefinitionId -> objectDefinitionDeployer.deploy(
 						objectDefinition));
 			}
@@ -965,14 +967,14 @@ public class ObjectDefinitionLocalServiceImpl
 	public void setAopProxy(Object aopProxy) {
 		super.setAopProxy(aopProxy);
 
-		Map<Long, List<ServiceRegistration<?>>> activeServiceRegistrationsMap =
-			new ConcurrentHashMap<>();
+		Map<String, List<ServiceRegistration<?>>>
+			activeServiceRegistrationsMap = new ConcurrentHashMap<>();
 		InactiveObjectDefinitionDeployer inactiveObjectDefinitionDeployer =
 			new InactiveObjectDefinitionDeployerImpl(
 				_bundleContext, _objectEntryService, _objectFieldLocalService,
 				_objectRelatedModelsProviderRegistrarHelper,
 				_objectRelationshipLocalService);
-		Map<Long, List<ServiceRegistration<?>>>
+		Map<String, List<ServiceRegistration<?>>>
 			inactiveServiceRegistrationsMap = new ConcurrentHashMap<>();
 		ObjectDefinitionDeployer objectDefinitionDeployer =
 			new ObjectDefinitionDeployerImpl(
@@ -1001,12 +1003,14 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						activeServiceRegistrationsMap.put(
-							objectDefinition.getObjectDefinitionId(),
+							companyId + StringPool.AT +
+								objectDefinition.getObjectDefinitionId(),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 					else {
 						inactiveServiceRegistrationsMap.put(
-							objectDefinition.getObjectDefinitionId(),
+							companyId + StringPool.AT +
+								objectDefinition.getObjectDefinitionId(),
 							inactiveObjectDefinitionDeployer.deploy(
 								objectDefinition));
 					}
@@ -1059,7 +1063,7 @@ public class ObjectDefinitionLocalServiceImpl
 							}
 						});
 
-					Map<Long, List<ServiceRegistration<?>>>
+					Map<String, List<ServiceRegistration<?>>>
 						serviceRegistrationsMap =
 							_serviceRegistrationsMaps.remove(
 								objectDefinitionDeployer);
@@ -1139,19 +1143,20 @@ public class ObjectDefinitionLocalServiceImpl
 
 		for (Map.Entry
 				<ObjectDefinitionDeployer,
-				 Map<Long, List<ServiceRegistration<?>>>> entry :
+				 Map<String, List<ServiceRegistration<?>>>> entry :
 					_serviceRegistrationsMaps.entrySet()) {
 
 			ObjectDefinitionDeployer objectDefinitionDeployer = entry.getKey();
 
 			objectDefinitionDeployer.undeploy(objectDefinition);
 
-			Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+			Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 				entry.getValue();
 
 			List<ServiceRegistration<?>> serviceRegistrations =
 				serviceRegistrationsMap.remove(
-					objectDefinition.getObjectDefinitionId());
+					objectDefinition.getCompanyId() + StringPool.AT +
+						objectDefinition.getObjectDefinitionId());
 
 			if (serviceRegistrations != null) {
 				for (ServiceRegistration<?> serviceRegistration :
@@ -1413,7 +1418,7 @@ public class ObjectDefinitionLocalServiceImpl
 	private ObjectDefinitionDeployer _addingObjectDefinitionDeployer(
 		ObjectDefinitionDeployer objectDefinitionDeployer) {
 
-		Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+		Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 			new ConcurrentHashMap<>();
 
 		_companyLocalService.forEachCompanyId(
@@ -1424,7 +1429,8 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						serviceRegistrationsMap.put(
-							objectDefinition.getObjectDefinitionId(),
+							companyId + StringPool.AT +
+								objectDefinition.getObjectDefinitionId(),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 				}
@@ -2783,7 +2789,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 	private final Map
 		<InactiveObjectDefinitionDeployer,
-		 Map<Long, List<ServiceRegistration<?>>>>
+		 Map<String, List<ServiceRegistration<?>>>>
 			_inactiveObjectDefinitionsServiceRegistrationsMaps =
 				Collections.synchronizedMap(new LinkedHashMap<>());
 
@@ -2880,7 +2886,7 @@ public class ObjectDefinitionLocalServiceImpl
 	private SearchLocalizationHelper _searchLocalizationHelper;
 
 	private final Map
-		<ObjectDefinitionDeployer, Map<Long, List<ServiceRegistration<?>>>>
+		<ObjectDefinitionDeployer, Map<String, List<ServiceRegistration<?>>>>
 			_serviceRegistrationsMaps = Collections.synchronizedMap(
 				new LinkedHashMap<>());
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/osgi/util/tracker/PortletTracker.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/osgi/util/tracker/PortletTracker.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletConfig;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletInstanceFactory;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
@@ -178,16 +179,21 @@ public class PortletTracker
 		FutureTask<com.liferay.portal.kernel.model.Portlet> futureTask =
 			new FutureTask<>(
 				() -> {
-					com.liferay.portal.kernel.model.Portlet addedPortletModel =
-						_addingPortlet(
-							serviceReference, portlet, finalPortletName,
-							finalPortletId);
+					try (SafeCloseable safeCloseable =
+							CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						(Long)serviceReference.getProperty("com.liferay.portlet.company"))) {
 
-					if (addedPortletModel == null) {
-						_bundleContext.ungetService(serviceReference);
+						com.liferay.portal.kernel.model.Portlet addedPortletModel =
+								_addingPortlet(
+										serviceReference, portlet, finalPortletName,
+										finalPortletId);
+
+						if (addedPortletModel == null) {
+							_bundleContext.ungetService(serviceReference);
+						}
+
+						return addedPortletModel;
 					}
-
-					return addedPortletModel;
 				});
 
 		if (_parallel &&
@@ -427,8 +433,7 @@ public class PortletTracker
 			com.liferay.portal.kernel.model.Portlet portletModel =
 				_buildPortletModel(
 					portletApp, portletId, bundle,
-					(Long)serviceReference.getProperty(
-						"com.liferay.portlet.company"));
+					CompanyThreadLocal.getCompanyId());
 
 			portletModel.setPortletName(portletName);
 			portletModel.setDisplayName(

--- a/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
@@ -523,6 +523,18 @@ public class DBPartitionUtil {
 								"companyId = ", fromCompanyId));
 					}
 
+					if (fromTableName.startsWith("Object") &&
+						dbInspector.hasColumn(fromTableName, "dbTableName")) {
+
+						statement.executeUpdate(
+							StringBundler.concat(
+								"update ", partitionTableName, " set ",
+								"dbTableName = REPLACE(dbTableName, ",
+								fromCompanyId, ", ", toCompanyId,
+								") where dbTableName like '%", fromCompanyId,
+								"%'"));
+					}
+
 					if (StringUtil.equalsIgnoreCase(fromTableName, "Group_")) {
 						statement.executeUpdate(
 							StringBundler.concat(

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -2927,7 +2927,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		new ConcurrentHashMap<>();
 	private static volatile Map<String, String> _portletIdsByStrutsPath;
 	private static final Map<String, Portlet> _portletsMap =
-		new ConcurrentHashMap<>();
+		new GlobalPortletsMap();
 	private static final Map<Long, Map<String, Portlet>> _portletsMaps =
 		new ConcurrentHashMap<>();
 
@@ -2960,6 +2960,33 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 	private ServiceTracker<FriendlyURLMapper, String[]> _serviceTracker;
 	private ServiceTrackerList<Consumer<Long>> _serviceTrackerList;
+
+	private static class GlobalPortletsMap
+		extends ConcurrentHashMap<String, Portlet> {
+
+		@Override
+		public Portlet get(Object key) {
+			Portlet portlet = super.get(key);
+
+			if (portlet != null && portlet.getCompanyId() == CompanyConstants.SYSTEM) {
+				return portlet;
+			}
+
+			return super.get(
+				key + StringPool.AT +
+					CompanyThreadLocal.getNonsystemCompanyId());
+		}
+
+		@Override
+		public Portlet put(String key, Portlet value) {
+			if (value == null || value.getCompanyId() == CompanyConstants.SYSTEM) {
+				return super.put(key, value);
+			}
+
+			return super.put(key + StringPool.AT + value.getCompanyId(), value);
+		}
+
+	}
 
 	private class FriendlyURLMapperServiceTrackerCustomizer
 		implements ServiceTrackerCustomizer<FriendlyURLMapper, String[]> {


### PR DESCRIPTION
- **LPD-42705 Replacing companyId references in dbTableName fields**
- **LPD-42541 The key for the object definition must include the companyId. This also impact regular db partitioning since ids can collide**
- **temp solution**
