### PR TITLE
LPD-88506 Add unified asset-entries headless search endpoint

### DIFF
--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetEntryServiceTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetEntryServiceTest.java
@@ -17,23 +17,33 @@ import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.view.count.ViewCountManager;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -245,6 +255,33 @@ public class AssetEntryServiceTest {
 
 		Assert.assertEquals(
 			topViewedAssetEntries.toString(), 1, topViewedAssetEntries.size());
+	}
+
+	@Test
+	public void testSearchWithSorts() throws Exception {
+		JournalArticle journalArticle1 = JournalTestUtil.addArticle(
+			_group.getGroupId(), 0);
+		JournalArticle journalArticle2 = JournalTestUtil.addArticle(
+			_group.getGroupId(), 0);
+
+		Hits hits = _assetEntryLocalService.search(
+			_group.getCompanyId(), new long[] {_group.getGroupId()},
+			TestPropsValues.getUserId(),
+			new long[] {_portal.getClassNameId(JournalArticle.class.getName())},
+			-1L, StringPool.BLANK, false,
+			new int[] {WorkflowConstants.STATUS_APPROVED}, 0, 50,
+			new Sort[] {new Sort(Field.MODIFIED_DATE, Sort.LONG_TYPE, true)});
+
+		Assert.assertTrue(hits.toString(), hits.getLength() >= 2);
+
+		Document[] documents = hits.getDocs();
+
+		Assert.assertEquals(
+			journalArticle2.getResourcePrimKey(),
+			GetterUtil.getLong(documents[0].get(Field.ENTRY_CLASS_PK)));
+		Assert.assertEquals(
+			journalArticle1.getResourcePrimKey(),
+			GetterUtil.getLong(documents[1].get(Field.ENTRY_CLASS_PK)));
 	}
 
 	@Test(expected = AssetCategoryException.class)

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/AssetEntry.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/AssetEntry.java
@@ -1,0 +1,650 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "Represents an asset entry returned by the unified asset search endpoint.",
+	value = "AssetEntry"
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "AssetEntry")
+public class AssetEntry implements Serializable {
+
+	public static AssetEntry toDTO(String json) {
+		return ObjectMapperUtil.readValue(AssetEntry.class, json);
+	}
+
+	public static AssetEntry unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(AssetEntry.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The asset entry's ID."
+	)
+	public Long getAssetEntryId() {
+		if (_assetEntryIdSupplier != null) {
+			assetEntryId = _assetEntryIdSupplier.get();
+
+			_assetEntryIdSupplier = null;
+		}
+
+		return assetEntryId;
+	}
+
+	public void setAssetEntryId(Long assetEntryId) {
+		this.assetEntryId = assetEntryId;
+
+		_assetEntryIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setAssetEntryId(
+		UnsafeSupplier<Long, Exception> assetEntryIdUnsafeSupplier) {
+
+		_assetEntryIdSupplier = () -> {
+			try {
+				return assetEntryIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The asset entry's ID.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long assetEntryId;
+
+	@JsonIgnore
+	private Supplier<Long> _assetEntryIdSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The localized asset type name (e.g., \"Web Content Article\" or \"Blogs Entry\")."
+	)
+	public String getAssetType() {
+		if (_assetTypeSupplier != null) {
+			assetType = _assetTypeSupplier.get();
+
+			_assetTypeSupplier = null;
+		}
+
+		return assetType;
+	}
+
+	public void setAssetType(String assetType) {
+		this.assetType = assetType;
+
+		_assetTypeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setAssetType(
+		UnsafeSupplier<String, Exception> assetTypeUnsafeSupplier) {
+
+		_assetTypeSupplier = () -> {
+			try {
+				return assetTypeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The localized asset type name (e.g., \"Web Content Article\" or \"Blogs Entry\")."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String assetType;
+
+	@JsonIgnore
+	private Supplier<String> _assetTypeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The fully qualified class name of the underlying asset."
+	)
+	public String getClassName() {
+		if (_classNameSupplier != null) {
+			className = _classNameSupplier.get();
+
+			_classNameSupplier = null;
+		}
+
+		return className;
+	}
+
+	public void setClassName(String className) {
+		this.className = className;
+
+		_classNameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setClassName(
+		UnsafeSupplier<String, Exception> classNameUnsafeSupplier) {
+
+		_classNameSupplier = () -> {
+			try {
+				return classNameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The fully qualified class name of the underlying asset."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String className;
+
+	@JsonIgnore
+	private Supplier<String> _classNameSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The class name ID of the underlying asset."
+	)
+	public Long getClassNameId() {
+		if (_classNameIdSupplier != null) {
+			classNameId = _classNameIdSupplier.get();
+
+			_classNameIdSupplier = null;
+		}
+
+		return classNameId;
+	}
+
+	public void setClassNameId(Long classNameId) {
+		this.classNameId = classNameId;
+
+		_classNameIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setClassNameId(
+		UnsafeSupplier<Long, Exception> classNameIdUnsafeSupplier) {
+
+		_classNameIdSupplier = () -> {
+			try {
+				return classNameIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The class name ID of the underlying asset.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long classNameId;
+
+	@JsonIgnore
+	private Supplier<Long> _classNameIdSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The primary key of the underlying asset."
+	)
+	public Long getClassPK() {
+		if (_classPKSupplier != null) {
+			classPK = _classPKSupplier.get();
+
+			_classPKSupplier = null;
+		}
+
+		return classPK;
+	}
+
+	public void setClassPK(Long classPK) {
+		this.classPK = classPK;
+
+		_classPKSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setClassPK(
+		UnsafeSupplier<Long, Exception> classPKUnsafeSupplier) {
+
+		_classPKSupplier = () -> {
+			try {
+				return classPKUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The primary key of the underlying asset.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long classPK;
+
+	@JsonIgnore
+	private Supplier<Long> _classPKSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The asset entry's description in the requesting locale."
+	)
+	public String getDescription() {
+		if (_descriptionSupplier != null) {
+			description = _descriptionSupplier.get();
+
+			_descriptionSupplier = null;
+		}
+
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+
+		_descriptionSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		_descriptionSupplier = () -> {
+			try {
+				return descriptionUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The asset entry's description in the requesting locale."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String description;
+
+	@JsonIgnore
+	private Supplier<String> _descriptionSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The localized descriptive name of the group where the asset entry lives."
+	)
+	public String getGroupDescriptiveName() {
+		if (_groupDescriptiveNameSupplier != null) {
+			groupDescriptiveName = _groupDescriptiveNameSupplier.get();
+
+			_groupDescriptiveNameSupplier = null;
+		}
+
+		return groupDescriptiveName;
+	}
+
+	public void setGroupDescriptiveName(String groupDescriptiveName) {
+		this.groupDescriptiveName = groupDescriptiveName;
+
+		_groupDescriptiveNameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setGroupDescriptiveName(
+		UnsafeSupplier<String, Exception> groupDescriptiveNameUnsafeSupplier) {
+
+		_groupDescriptiveNameSupplier = () -> {
+			try {
+				return groupDescriptiveNameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The localized descriptive name of the group where the asset entry lives."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String groupDescriptiveName;
+
+	@JsonIgnore
+	private Supplier<String> _groupDescriptiveNameSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The asset entry's title in the requesting locale."
+	)
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The asset entry's title in the requesting locale."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof AssetEntry)) {
+			return false;
+		}
+
+		AssetEntry assetEntry = (AssetEntry)object;
+
+		return Objects.equals(toString(), assetEntry.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		Long assetEntryId = getAssetEntryId();
+
+		if (assetEntryId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"assetEntryId\": ");
+
+			sb.append(assetEntryId);
+		}
+
+		String assetType = getAssetType();
+
+		if (assetType != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"assetType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetType));
+
+			sb.append("\"");
+		}
+
+		String className = getClassName();
+
+		if (className != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"className\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(className));
+
+			sb.append("\"");
+		}
+
+		Long classNameId = getClassNameId();
+
+		if (classNameId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"classNameId\": ");
+
+			sb.append(classNameId);
+		}
+
+		Long classPK = getClassPK();
+
+		if (classPK != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"classPK\": ");
+
+			sb.append(classPK);
+		}
+
+		String description = getDescription();
+
+		if (description != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		String groupDescriptiveName = getGroupDescriptiveName();
+
+		if (groupDescriptiveName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"groupDescriptiveName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(groupDescriptiveName));
+
+			sb.append("\"");
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.delivery.dto.v1_0.AssetEntry",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:696037818

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/AssetEntryResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/AssetEntryResource.java
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.resource.v1_0;
+
+import com.liferay.headless.delivery.dto.v1_0.AssetEntry;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-delivery/v1.0
+ *
+ * @author Javier Gamarra
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface AssetEntryResource {
+
+	public Page<AssetEntry> getAssetEntriesPage(
+			Long[] groupIds, String search, Boolean showNonindexable,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
+	public Response postAssetEntriesPageExportBatch(
+			Long[] groupIds, String search, Boolean showNonindexable,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
+			String contentType, String fieldNames)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public AssetEntryResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1192055749

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/AssetEntry.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/AssetEntry.java
@@ -1,0 +1,228 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.client.dto.v1_0;
+
+import com.liferay.headless.delivery.client.function.UnsafeSupplier;
+import com.liferay.headless.delivery.client.serdes.v1_0.AssetEntrySerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class AssetEntry implements Cloneable, Serializable {
+
+	public static AssetEntry toDTO(String json) {
+		return AssetEntrySerDes.toDTO(json);
+	}
+
+	public Long getAssetEntryId() {
+		return assetEntryId;
+	}
+
+	public void setAssetEntryId(Long assetEntryId) {
+		this.assetEntryId = assetEntryId;
+	}
+
+	public void setAssetEntryId(
+		UnsafeSupplier<Long, Exception> assetEntryIdUnsafeSupplier) {
+
+		try {
+			assetEntryId = assetEntryIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long assetEntryId;
+
+	public String getAssetType() {
+		return assetType;
+	}
+
+	public void setAssetType(String assetType) {
+		this.assetType = assetType;
+	}
+
+	public void setAssetType(
+		UnsafeSupplier<String, Exception> assetTypeUnsafeSupplier) {
+
+		try {
+			assetType = assetTypeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String assetType;
+
+	public String getClassName() {
+		return className;
+	}
+
+	public void setClassName(String className) {
+		this.className = className;
+	}
+
+	public void setClassName(
+		UnsafeSupplier<String, Exception> classNameUnsafeSupplier) {
+
+		try {
+			className = classNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String className;
+
+	public Long getClassNameId() {
+		return classNameId;
+	}
+
+	public void setClassNameId(Long classNameId) {
+		this.classNameId = classNameId;
+	}
+
+	public void setClassNameId(
+		UnsafeSupplier<Long, Exception> classNameIdUnsafeSupplier) {
+
+		try {
+			classNameId = classNameIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long classNameId;
+
+	public Long getClassPK() {
+		return classPK;
+	}
+
+	public void setClassPK(Long classPK) {
+		this.classPK = classPK;
+	}
+
+	public void setClassPK(
+		UnsafeSupplier<Long, Exception> classPKUnsafeSupplier) {
+
+		try {
+			classPK = classPKUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long classPK;
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String description;
+
+	public String getGroupDescriptiveName() {
+		return groupDescriptiveName;
+	}
+
+	public void setGroupDescriptiveName(String groupDescriptiveName) {
+		this.groupDescriptiveName = groupDescriptiveName;
+	}
+
+	public void setGroupDescriptiveName(
+		UnsafeSupplier<String, Exception> groupDescriptiveNameUnsafeSupplier) {
+
+		try {
+			groupDescriptiveName = groupDescriptiveNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String groupDescriptiveName;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
+
+	@Override
+	public AssetEntry clone() throws CloneNotSupportedException {
+		return (AssetEntry)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof AssetEntry)) {
+			return false;
+		}
+
+		AssetEntry assetEntry = (AssetEntry)object;
+
+		return Objects.equals(toString(), assetEntry.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return AssetEntrySerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-997892772

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/AssetEntryResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/AssetEntryResource.java
@@ -1,0 +1,458 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.client.resource.v1_0;
+
+import com.liferay.headless.delivery.client.dto.v1_0.AssetEntry;
+import com.liferay.headless.delivery.client.http.HttpInvoker;
+import com.liferay.headless.delivery.client.pagination.Page;
+import com.liferay.headless.delivery.client.pagination.Pagination;
+import com.liferay.headless.delivery.client.problem.Problem;
+import com.liferay.headless.delivery.client.serdes.v1_0.AssetEntrySerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public interface AssetEntryResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Page<AssetEntry> getAssetEntriesPage(
+			Long[] groupIds, String search, Boolean showNonindexable,
+			String filterString, Pagination pagination, String sortString)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getAssetEntriesPageHttpResponse(
+			Long[] groupIds, String search, Boolean showNonindexable,
+			String filterString, Pagination pagination, String sortString)
+		throws Exception;
+
+	public void postAssetEntriesPageExportBatch(
+			Long[] groupIds, String search, Boolean showNonindexable,
+			String filterString, String sortString, String callbackURL,
+			String contentType, String fieldNames)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postAssetEntriesPageExportBatchHttpResponse(
+			Long[] groupIds, String search, Boolean showNonindexable,
+			String filterString, String sortString, String callbackURL,
+			String contentType, String fieldNames)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public AssetEntryResource build() {
+			return new AssetEntryResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class AssetEntryResourceImpl implements AssetEntryResource {
+
+		public Page<AssetEntry> getAssetEntriesPage(
+				Long[] groupIds, String search, Boolean showNonindexable,
+				String filterString, Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getAssetEntriesPageHttpResponse(
+					groupIds, search, showNonindexable, filterString,
+					pagination, sortString);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, AssetEntrySerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getAssetEntriesPageHttpResponse(
+				Long[] groupIds, String search, Boolean showNonindexable,
+				String filterString, Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (groupIds != null) {
+				for (int i = 0; i < groupIds.length; i++) {
+					httpInvoker.parameter(
+						"groupIds", String.valueOf(groupIds[i]));
+				}
+			}
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (showNonindexable != null) {
+				httpInvoker.parameter(
+					"showNonindexable", String.valueOf(showNonindexable));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/asset-entries");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postAssetEntriesPageExportBatch(
+				Long[] groupIds, String search, Boolean showNonindexable,
+				String filterString, String sortString, String callbackURL,
+				String contentType, String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAssetEntriesPageExportBatchHttpResponse(
+					groupIds, search, showNonindexable, filterString,
+					sortString, callbackURL, contentType, fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postAssetEntriesPageExportBatchHttpResponse(
+					Long[] groupIds, String search, Boolean showNonindexable,
+					String filterString, String sortString, String callbackURL,
+					String contentType, String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (groupIds != null) {
+				for (int i = 0; i < groupIds.length; i++) {
+					httpInvoker.parameter(
+						"groupIds", String.valueOf(groupIds[i]));
+				}
+			}
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (showNonindexable != null) {
+				httpInvoker.parameter(
+					"showNonindexable", String.valueOf(showNonindexable));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/asset-entries/export-batch");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private AssetEntryResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			AssetEntryResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:805351637

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/AssetEntrySerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/AssetEntrySerDes.java
@@ -1,0 +1,404 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.client.serdes.v1_0;
+
+import com.liferay.headless.delivery.client.dto.v1_0.AssetEntry;
+import com.liferay.headless.delivery.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class AssetEntrySerDes {
+
+	public static AssetEntry toDTO(String json) {
+		AssetEntryJSONParser assetEntryJSONParser = new AssetEntryJSONParser();
+
+		return assetEntryJSONParser.parseToDTO(json);
+	}
+
+	public static AssetEntry[] toDTOs(String json) {
+		AssetEntryJSONParser assetEntryJSONParser = new AssetEntryJSONParser();
+
+		return assetEntryJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(AssetEntry assetEntry) {
+		if (assetEntry == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (assetEntry.getAssetEntryId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"assetEntryId\": ");
+
+			sb.append(assetEntry.getAssetEntryId());
+		}
+
+		if (assetEntry.getAssetType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"assetType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetEntry.getAssetType()));
+
+			sb.append("\"");
+		}
+
+		if (assetEntry.getClassName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"className\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetEntry.getClassName()));
+
+			sb.append("\"");
+		}
+
+		if (assetEntry.getClassNameId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"classNameId\": ");
+
+			sb.append(assetEntry.getClassNameId());
+		}
+
+		if (assetEntry.getClassPK() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"classPK\": ");
+
+			sb.append(assetEntry.getClassPK());
+		}
+
+		if (assetEntry.getDescription() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetEntry.getDescription()));
+
+			sb.append("\"");
+		}
+
+		if (assetEntry.getGroupDescriptiveName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"groupDescriptiveName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetEntry.getGroupDescriptiveName()));
+
+			sb.append("\"");
+		}
+
+		if (assetEntry.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetEntry.getTitle()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		AssetEntryJSONParser assetEntryJSONParser = new AssetEntryJSONParser();
+
+		return assetEntryJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(AssetEntry assetEntry) {
+		if (assetEntry == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (assetEntry.getAssetEntryId() == null) {
+			map.put("assetEntryId", null);
+		}
+		else {
+			map.put(
+				"assetEntryId", String.valueOf(assetEntry.getAssetEntryId()));
+		}
+
+		if (assetEntry.getAssetType() == null) {
+			map.put("assetType", null);
+		}
+		else {
+			map.put("assetType", String.valueOf(assetEntry.getAssetType()));
+		}
+
+		if (assetEntry.getClassName() == null) {
+			map.put("className", null);
+		}
+		else {
+			map.put("className", String.valueOf(assetEntry.getClassName()));
+		}
+
+		if (assetEntry.getClassNameId() == null) {
+			map.put("classNameId", null);
+		}
+		else {
+			map.put("classNameId", String.valueOf(assetEntry.getClassNameId()));
+		}
+
+		if (assetEntry.getClassPK() == null) {
+			map.put("classPK", null);
+		}
+		else {
+			map.put("classPK", String.valueOf(assetEntry.getClassPK()));
+		}
+
+		if (assetEntry.getDescription() == null) {
+			map.put("description", null);
+		}
+		else {
+			map.put("description", String.valueOf(assetEntry.getDescription()));
+		}
+
+		if (assetEntry.getGroupDescriptiveName() == null) {
+			map.put("groupDescriptiveName", null);
+		}
+		else {
+			map.put(
+				"groupDescriptiveName",
+				String.valueOf(assetEntry.getGroupDescriptiveName()));
+		}
+
+		if (assetEntry.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put("title", String.valueOf(assetEntry.getTitle()));
+		}
+
+		return map;
+	}
+
+	public static class AssetEntryJSONParser
+		extends BaseJSONParser<AssetEntry> {
+
+		@Override
+		protected AssetEntry createDTO() {
+			return new AssetEntry();
+		}
+
+		@Override
+		protected AssetEntry[] createDTOArray(int size) {
+			return new AssetEntry[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "assetEntryId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "assetType")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "className")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "classNameId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "classPK")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "description")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "groupDescriptiveName")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			AssetEntry assetEntry, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "assetEntryId")) {
+				if (jsonParserFieldValue != null) {
+					assetEntry.setAssetEntryId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "assetType")) {
+				if (jsonParserFieldValue != null) {
+					assetEntry.setAssetType((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "className")) {
+				if (jsonParserFieldValue != null) {
+					assetEntry.setClassName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "classNameId")) {
+				if (jsonParserFieldValue != null) {
+					assetEntry.setClassNameId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "classPK")) {
+				if (jsonParserFieldValue != null) {
+					assetEntry.setClassPK(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "description")) {
+				if (jsonParserFieldValue != null) {
+					assetEntry.setDescription((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "groupDescriptiveName")) {
+
+				if (jsonParserFieldValue != null) {
+					assetEntry.setGroupDescriptiveName(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					assetEntry.setTitle((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-953940785

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -56,6 +56,54 @@ components:
                     readOnly: true
                     type: number
             type: object
+        AssetEntry:
+            description:
+                Represents an asset entry returned by the unified asset search endpoint.
+            properties:
+                assetEntryId:
+                    description:
+                        The asset entry's ID.
+                    format: int64
+                    readOnly: true
+                    type: integer
+                assetType:
+                    description:
+                        The localized asset type name (e.g., "Web Content Article" or "Blogs Entry").
+                    readOnly: true
+                    type: string
+                className:
+                    description:
+                        The fully qualified class name of the underlying asset.
+                    readOnly: true
+                    type: string
+                classNameId:
+                    description:
+                        The class name ID of the underlying asset.
+                    format: int64
+                    readOnly: true
+                    type: integer
+                classPK:
+                    description:
+                        The primary key of the underlying asset.
+                    format: int64
+                    readOnly: true
+                    type: integer
+                description:
+                    description:
+                        The asset entry's description in the requesting locale.
+                    readOnly: true
+                    type: string
+                groupDescriptiveName:
+                    description:
+                        The localized descriptive name of the group where the asset entry lives.
+                    readOnly: true
+                    type: string
+                title:
+                    description:
+                        The asset entry's title in the requesting locale.
+                    readOnly: true
+                    type: string
+            type: object
         BlogPosting:
             description:
                 Represents a blog post. See [BlogPosting](https://www.schema.org/BlogPosting) for more information.
@@ -6263,6 +6311,65 @@ info:
     version: v1.0
 openapi: 3.0.1
 paths:
+    "/asset-entries":
+        get:
+            description:
+                Retrieves the asset entries in the given groups, across one or more class names, mirroring the legacy
+                asset browser item selector search. Results can be paginated, filtered, searched, and sorted.
+            operationId: getAssetEntriesPage
+            parameters:
+                -   in: query
+                    name: filter
+                    schema:
+                        type: string
+                -   in: query
+                    description:
+                        Scopes the search to the union of the given groups. When omitted, the search runs across every
+                        group the user has read permission to.
+                    name: groupIds
+                    schema:
+                        items:
+                            format: int64
+                            type: integer
+                        type: array
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+                -   in: query
+                    name: showNonindexable
+                    schema:
+                        type: boolean
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
+                -   in: header
+                    name: Accept-Language
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/AssetEntry"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/AssetEntry"
+                                type: array
+            tags: ["AssetEntry"]
     "/asset-libraries/{assetLibraryId}/content-elements":
         get:
             operationId: getAssetLibraryContentElementsPage

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/AssetEntryDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/AssetEntryDTOConverter.java
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.dto.v1_0.converter;
+
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.asset.kernel.model.ClassType;
+import com.liferay.asset.kernel.model.ClassTypeReader;
+import com.liferay.headless.delivery.dto.v1_0.AssetEntry;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Luis Ortiz
+ */
+@Component(
+	property = "dto.class.name=com.liferay.asset.kernel.model.AssetEntry",
+	service = DTOConverter.class
+)
+public class AssetEntryDTOConverter
+	implements DTOConverter
+		<com.liferay.asset.kernel.model.AssetEntry, AssetEntry> {
+
+	@Override
+	public String getContentType() {
+		return AssetEntry.class.getSimpleName();
+	}
+
+	@Override
+	public AssetEntry toDTO(
+		DTOConverterContext dtoConverterContext,
+		com.liferay.asset.kernel.model.AssetEntry serviceBuilderAssetEntry) {
+
+		AssetRendererFactory<?> assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				serviceBuilderAssetEntry.getClassName());
+
+		Group group = _groupLocalService.fetchGroup(
+			serviceBuilderAssetEntry.getGroupId());
+
+		Locale locale = dtoConverterContext.getLocale();
+
+		return new AssetEntry() {
+			{
+				setAssetEntryId(serviceBuilderAssetEntry::getEntryId);
+				setAssetType(
+					() -> {
+						if (!assetRendererFactory.isSupportsClassTypes()) {
+							return assetRendererFactory.getTypeName(
+								locale,
+								serviceBuilderAssetEntry.getClassTypeId());
+						}
+
+						ClassTypeReader classTypeReader =
+							assetRendererFactory.getClassTypeReader();
+
+						ClassType classType = classTypeReader.getClassType(
+							serviceBuilderAssetEntry.getClassTypeId(), locale);
+
+						return classType.getName();
+					});
+				setClassName(serviceBuilderAssetEntry::getClassName);
+				setClassNameId(serviceBuilderAssetEntry::getClassNameId);
+				setClassPK(serviceBuilderAssetEntry::getClassPK);
+				setDescription(
+					() -> serviceBuilderAssetEntry.getDescription(locale));
+				setGroupDescriptiveName(() -> group.getDescriptiveName(locale));
+				setTitle(() -> serviceBuilderAssetEntry.getTitle(locale));
+			}
+		};
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -28,6 +28,7 @@ import com.liferay.headless.delivery.dto.v1_0.StructuredContentFolder;
 import com.liferay.headless.delivery.dto.v1_0.WikiNode;
 import com.liferay.headless.delivery.dto.v1_0.WikiPage;
 import com.liferay.headless.delivery.dto.v1_0.WikiPageAttachment;
+import com.liferay.headless.delivery.resource.v1_0.AssetEntryResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingImageResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingResource;
 import com.liferay.headless.delivery.resource.v1_0.CommentResource;
@@ -86,6 +87,14 @@ import org.osgi.service.component.ComponentServiceObjects;
  */
 @Generated("")
 public class Mutation {
+
+	public static void setAssetEntryResourceComponentServiceObjects(
+		ComponentServiceObjects<AssetEntryResource>
+			assetEntryResourceComponentServiceObjects) {
+
+		_assetEntryResourceComponentServiceObjects =
+			assetEntryResourceComponentServiceObjects;
+	}
 
 	public static void setBlogPostingResourceComponentServiceObjects(
 		ComponentServiceObjects<BlogPostingResource>
@@ -296,6 +305,29 @@ public class Mutation {
 
 		_wikiPageAttachmentResourceComponentServiceObjects =
 			wikiPageAttachmentResourceComponentServiceObjects;
+	}
+
+	@GraphQLField
+	public Response createAssetEntriesPageExportBatch(
+			@GraphQLName("groupIds") Long[] groupIds,
+			@GraphQLName("search") String search,
+			@GraphQLName("showNonindexable") Boolean showNonindexable,
+			@GraphQLName("filter") String filterString,
+			@GraphQLName("sort") String sortsString,
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("contentType") String contentType,
+			@GraphQLName("fieldNames") String fieldNames)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_assetEntryResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			assetEntryResource ->
+				assetEntryResource.postAssetEntriesPageExportBatch(
+					groupIds, search, showNonindexable,
+					_filterBiFunction.apply(assetEntryResource, filterString),
+					_sortsBiFunction.apply(assetEntryResource, sortsString),
+					callbackURL, contentType, fieldNames));
 	}
 
 	@GraphQLField(
@@ -6273,6 +6305,25 @@ public class Mutation {
 		}
 	}
 
+	private void _populateResourceContext(AssetEntryResource assetEntryResource)
+		throws Exception {
+
+		assetEntryResource.setContextAcceptLanguage(_acceptLanguage);
+		assetEntryResource.setContextCompany(_company);
+		assetEntryResource.setContextHttpServletRequest(_httpServletRequest);
+		assetEntryResource.setContextHttpServletResponse(_httpServletResponse);
+		assetEntryResource.setContextUriInfo(_uriInfo);
+		assetEntryResource.setContextUser(_user);
+		assetEntryResource.setGroupLocalService(_groupLocalService);
+		assetEntryResource.setRoleLocalService(_roleLocalService);
+
+		assetEntryResource.setVulcanBatchEngineExportTaskResource(
+			_vulcanBatchEngineExportTaskResource);
+
+		assetEntryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
+	}
+
 	private void _populateResourceContext(
 			BlogPostingResource blogPostingResource)
 		throws Exception {
@@ -6836,6 +6887,8 @@ public class Mutation {
 			_vulcanBatchEngineImportTaskResource);
 	}
 
+	private static ComponentServiceObjects<AssetEntryResource>
+		_assetEntryResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BlogPostingResource>
 		_blogPostingResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BlogPostingImageResource>
@@ -6908,4 +6961,4 @@ public class Mutation {
 		_vulcanBatchEngineImportTaskResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:505624026
+// LIFERAY-REST-BUILDER-HASH:-996168166

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.delivery.internal.graphql.query.v1_0;
 
+import com.liferay.headless.delivery.dto.v1_0.AssetEntry;
 import com.liferay.headless.delivery.dto.v1_0.BlogPosting;
 import com.liferay.headless.delivery.dto.v1_0.BlogPostingImage;
 import com.liferay.headless.delivery.dto.v1_0.Comment;
@@ -34,6 +35,7 @@ import com.liferay.headless.delivery.dto.v1_0.StructuredContentFolder;
 import com.liferay.headless.delivery.dto.v1_0.WikiNode;
 import com.liferay.headless.delivery.dto.v1_0.WikiPage;
 import com.liferay.headless.delivery.dto.v1_0.WikiPageAttachment;
+import com.liferay.headless.delivery.resource.v1_0.AssetEntryResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingImageResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingResource;
 import com.liferay.headless.delivery.resource.v1_0.CommentResource;
@@ -98,6 +100,14 @@ import org.osgi.service.component.ComponentServiceObjects;
  */
 @Generated("")
 public class Query {
+
+	public static void setAssetEntryResourceComponentServiceObjects(
+		ComponentServiceObjects<AssetEntryResource>
+			assetEntryResourceComponentServiceObjects) {
+
+		_assetEntryResourceComponentServiceObjects =
+			assetEntryResourceComponentServiceObjects;
+	}
 
 	public static void setBlogPostingResourceComponentServiceObjects(
 		ComponentServiceObjects<BlogPostingResource>
@@ -316,6 +326,35 @@ public class Query {
 
 		_wikiPageAttachmentResourceComponentServiceObjects =
 			wikiPageAttachmentResourceComponentServiceObjects;
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetEntries(filter: ___, groupIds: ___, page: ___, pageSize: ___, search: ___, showNonindexable: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the asset entries in the given groups, across one or more class names, mirroring the legacy asset browser item selector search. Results can be paginated, filtered, searched, and sorted."
+	)
+	public AssetEntryPage assetEntries(
+			@GraphQLName("groupIds") Long[] groupIds,
+			@GraphQLName("search") String search,
+			@GraphQLName("showNonindexable") Boolean showNonindexable,
+			@GraphQLName("filter") String filterString,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page,
+			@GraphQLName("sort") String sortsString)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_assetEntryResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			assetEntryResource -> new AssetEntryPage(
+				assetEntryResource.getAssetEntriesPage(
+					groupIds, search, showNonindexable,
+					_filterBiFunction.apply(assetEntryResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortsBiFunction.apply(assetEntryResource, sortsString))));
 	}
 
 	/**
@@ -5758,6 +5797,44 @@ public class Query {
 
 	}
 
+	@GraphQLName("AssetEntryPage")
+	public class AssetEntryPage {
+
+		public AssetEntryPage(Page assetEntryPage) {
+			actions = assetEntryPage.getActions();
+
+			facets = assetEntryPage.getFacets();
+
+			items = assetEntryPage.getItems();
+			lastPage = assetEntryPage.getLastPage();
+			page = assetEntryPage.getPage();
+			pageSize = assetEntryPage.getPageSize();
+			totalCount = assetEntryPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
+
+		@GraphQLField
+		protected java.util.Collection<AssetEntry> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
 	@GraphQLName("BlogPostingPage")
 	public class BlogPostingPage {
 
@@ -7030,6 +7107,23 @@ public class Query {
 		}
 	}
 
+	private void _populateResourceContext(AssetEntryResource assetEntryResource)
+		throws Exception {
+
+		assetEntryResource.setContextAcceptLanguage(_acceptLanguage);
+		assetEntryResource.setContextCompany(_company);
+		assetEntryResource.setContextHttpServletRequest(_httpServletRequest);
+		assetEntryResource.setContextHttpServletResponse(_httpServletResponse);
+		assetEntryResource.setContextUriInfo(_uriInfo);
+		assetEntryResource.setContextUser(_user);
+		assetEntryResource.setGroupLocalService(_groupLocalService);
+		assetEntryResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		assetEntryResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		assetEntryResource.setRoleLocalService(_roleLocalService);
+	}
+
 	private void _populateResourceContext(
 			BlogPostingResource blogPostingResource)
 		throws Exception {
@@ -7559,6 +7653,8 @@ public class Query {
 		wikiPageAttachmentResource.setRoleLocalService(_roleLocalService);
 	}
 
+	private static ComponentServiceObjects<AssetEntryResource>
+		_assetEntryResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BlogPostingResource>
 		_blogPostingResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BlogPostingImageResource>
@@ -7633,4 +7729,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1704935486
+// LIFERAY-REST-BUILDER-HASH:-1851934736

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -7,6 +7,7 @@ package com.liferay.headless.delivery.internal.graphql.servlet.v1_0;
 
 import com.liferay.headless.delivery.internal.graphql.mutation.v1_0.Mutation;
 import com.liferay.headless.delivery.internal.graphql.query.v1_0.Query;
+import com.liferay.headless.delivery.internal.resource.v1_0.AssetEntryResourceImpl;
 import com.liferay.headless.delivery.internal.resource.v1_0.BlogPostingImageResourceImpl;
 import com.liferay.headless.delivery.internal.resource.v1_0.BlogPostingResourceImpl;
 import com.liferay.headless.delivery.internal.resource.v1_0.CommentResourceImpl;
@@ -34,6 +35,7 @@ import com.liferay.headless.delivery.internal.resource.v1_0.StructuredContentRes
 import com.liferay.headless.delivery.internal.resource.v1_0.WikiNodeResourceImpl;
 import com.liferay.headless.delivery.internal.resource.v1_0.WikiPageAttachmentResourceImpl;
 import com.liferay.headless.delivery.internal.resource.v1_0.WikiPageResourceImpl;
+import com.liferay.headless.delivery.resource.v1_0.AssetEntryResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingImageResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingResource;
 import com.liferay.headless.delivery.resource.v1_0.CommentResource;
@@ -86,6 +88,8 @@ public class ServletDataImpl implements ServletData {
 
 	@Activate
 	public void activate(BundleContext bundleContext) {
+		Mutation.setAssetEntryResourceComponentServiceObjects(
+			_assetEntryResourceComponentServiceObjects);
 		Mutation.setBlogPostingResourceComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects);
 		Mutation.setBlogPostingImageResourceComponentServiceObjects(
@@ -139,6 +143,8 @@ public class ServletDataImpl implements ServletData {
 		Mutation.setWikiPageAttachmentResourceComponentServiceObjects(
 			_wikiPageAttachmentResourceComponentServiceObjects);
 
+		Query.setAssetEntryResourceComponentServiceObjects(
+			_assetEntryResourceComponentServiceObjects);
 		Query.setBlogPostingResourceComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects);
 		Query.setBlogPostingImageResourceComponentServiceObjects(
@@ -229,6 +235,11 @@ public class ServletDataImpl implements ServletData {
 		_resourceMethodObjectValuePairs =
 			new HashMap<String, ObjectValuePair<Class<?>, String>>() {
 				{
+					put(
+						"mutation#createAssetEntriesPageExportBatch",
+						new ObjectValuePair<>(
+							AssetEntryResourceImpl.class,
+							"postAssetEntriesPageExportBatch"));
 					put(
 						"mutation#deleteBlogPosting",
 						new ObjectValuePair<>(
@@ -1866,6 +1877,11 @@ public class ServletDataImpl implements ServletData {
 							"postWikiPageWikiPageAttachmentsPageExportBatch"));
 
 					put(
+						"query#assetEntries",
+						new ObjectValuePair<>(
+							AssetEntryResourceImpl.class,
+							"getAssetEntriesPage"));
+					put(
 						"query#blogPosting",
 						new ObjectValuePair<>(
 							BlogPostingResourceImpl.class, "getBlogPosting"));
@@ -2985,6 +3001,10 @@ public class ServletDataImpl implements ServletData {
 			};
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<AssetEntryResource>
+		_assetEntryResourceComponentServiceObjects;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
 	private ComponentServiceObjects<BlogPostingResource>
 		_blogPostingResourceComponentServiceObjects;
 
@@ -3093,4 +3113,4 @@ public class ServletDataImpl implements ServletData {
 		_contentSetElementResourceComponentServiceObjects;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1122700236
+// LIFERAY-REST-BUILDER-HASH:-502818875

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/AssetEntryEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/AssetEntryEntityModel.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.odata.entity.v1_0;
+
+import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.entity.IntegerEntityField;
+
+import java.util.Map;
+
+/**
+ * @author Luis Ortiz
+ */
+public class AssetEntryEntityModel implements EntityModel {
+
+	public AssetEntryEntityModel() {
+		_entityFieldsMap = EntityFieldsMapFactory.create(
+			new EntityField(
+				"classNameId", EntityField.Type.INTEGER,
+				locale -> Field.ENTRY_CLASS_NAME,
+				locale -> Field.ENTRY_CLASS_NAME,
+				value -> PortalUtil.getClassName(GetterUtil.getLong(value))),
+			new EntityField(
+				"status", EntityField.Type.STRING, locale -> Field.STATUS,
+				locale -> Field.STATUS,
+				value -> String.valueOf(
+					WorkflowConstants.getLabelStatus(String.valueOf(value)))),
+			new IntegerEntityField(
+				"classTypeId", locale -> Field.CLASS_TYPE_ID));
+	}
+
+	@Override
+	public Map<String, EntityField> getEntityFieldsMap() {
+		return _entityFieldsMap;
+	}
+
+	private final Map<String, EntityField> _entityFieldsMap;
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/AssetEntryResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/AssetEntryResourceImpl.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.resource.v1_0;
+
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.search.AssetSearcherFactoryUtil;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
+import com.liferay.headless.delivery.dto.v1_0.AssetEntry;
+import com.liferay.headless.delivery.internal.odata.entity.v1_0.AssetEntryEntityModel;
+import com.liferay.headless.delivery.resource.v1_0.AssetEntryResource;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.SearchUtil;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Luis Ortiz
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/asset-entry.properties",
+	scope = ServiceScope.PROTOTYPE, service = AssetEntryResource.class
+)
+public class AssetEntryResourceImpl extends BaseAssetEntryResourceImpl {
+
+	@Override
+	public Page<AssetEntry> getAssetEntriesPage(
+			Long[] groupIds, String search, Boolean showNonindexable,
+			Filter filter, Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
+
+		assetEntryQuery.setClassNameIds(
+			AssetRendererFactoryRegistryUtil.getClassNameIds(
+				contextCompany.getCompanyId()));
+
+		return SearchUtil.search(
+			null,
+			booleanQuery -> {
+			},
+			filter,
+			AssetSearcherFactoryUtil.createBaseSearcher(assetEntryQuery),
+			GetterUtil.getString(search), pagination,
+			queryConfig -> queryConfig.setSelectedFieldNames(
+				Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK),
+			searchContext -> {
+				searchContext.setAttribute(
+					"showNonindexable",
+					GetterUtil.getBoolean(showNonindexable));
+				searchContext.setCompanyId(contextCompany.getCompanyId());
+
+				if (ArrayUtil.isNotEmpty(groupIds)) {
+					searchContext.setGroupIds(
+						ArrayUtil.toLongArray(Arrays.asList(groupIds)));
+				}
+
+				searchContext.setUserId(contextUser.getUserId());
+			},
+			sorts, document -> _toAssetEntry(document));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _entityModel;
+	}
+
+	private AssetEntry _toAssetEntry(Document document) throws Exception {
+		com.liferay.asset.kernel.model.AssetEntry serviceBuilderAssetEntry =
+			_assetEntryLocalService.fetchEntry(
+				GetterUtil.getString(document.get(Field.ENTRY_CLASS_NAME)),
+				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)));
+
+		if (serviceBuilderAssetEntry == null) {
+			return null;
+		}
+
+		return _assetEntryDTOConverter.toDTO(
+			new DefaultDTOConverterContext(
+				contextAcceptLanguage.isAcceptAllLanguages(),
+				Collections.emptyMap(), _dtoConverterRegistry,
+				serviceBuilderAssetEntry.getEntryId(),
+				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
+				contextUser),
+			serviceBuilderAssetEntry);
+	}
+
+	private static final EntityModel _entityModel = new AssetEntryEntityModel();
+
+	@Reference(
+		target = "(component.name=com.liferay.headless.delivery.internal.dto.v1_0.converter.AssetEntryDTOConverter)"
+	)
+	private DTOConverter<com.liferay.asset.kernel.model.AssetEntry, AssetEntry>
+		_assetEntryDTOConverter;
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Reference
+	private DTOConverterRegistry _dtoConverterRegistry;
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseAssetEntryResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseAssetEntryResourceImpl.java
@@ -1,0 +1,901 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.resource.v1_0;
+
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.headless.delivery.dto.v1_0.AssetEntry;
+import com.liferay.headless.delivery.dto.v1_0.DefaultValue;
+import com.liferay.headless.delivery.resource.v1_0.AssetEntryResource;
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.io.Serializable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseAssetEntryResourceImpl
+	implements AssetEntryResource, EntityModelResource,
+			   VulcanBatchEngineTaskItemDelegate<AssetEntry> {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-delivery/v1.0/asset-entries'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the asset entries in the given groups, across one or more class names, mirroring the legacy asset browser item selector search. Results can be paginated, filtered, searched, and sorted."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "groupIds"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "showNonindexable"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetEntry")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/asset-entries")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<AssetEntry> getAssetEntriesPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("groupIds")
+			Long[] groupIds,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("showNonindexable")
+			Boolean showNonindexable,
+			@jakarta.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@jakarta.ws.rs.core.Context Pagination pagination,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/asset-entries/export-batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "groupIds"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "showNonindexable"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "contentType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fieldNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetEntry")}
+	)
+	@jakarta.ws.rs.Consumes("application/json")
+	@jakarta.ws.rs.Path("/asset-entries/export-batch")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces("application/json")
+	@Override
+	public Response postAssetEntriesPageExportBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("groupIds")
+			Long[] groupIds,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("showNonindexable")
+			Boolean showNonindexable,
+			@jakarta.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.DefaultValue("JSON")
+			@jakarta.ws.rs.QueryParam("contentType")
+			String contentType,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("fieldNames")
+			String fieldNames)
+		throws Exception {
+
+		vulcanBatchEngineExportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineExportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineExportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineExportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineExportTaskResource.setContextUser(contextUser);
+		vulcanBatchEngineExportTaskResource.setGroupLocalService(
+			groupLocalService);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineExportTaskResource.postExportTask(
+				AssetEntry.class.getName(), callbackURL, contentType,
+				fieldNames)
+		).build();
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			Collection<AssetEntry> assetEntries,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void delete(
+			Collection<AssetEntry> assetEntries,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	public String getResourceName() {
+		return "AssetEntry";
+	}
+
+	public String getVersion() {
+		return "v1.0";
+	}
+
+	@Override
+	public Page<AssetEntry> read(
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		return getAssetEntriesPage(
+			(Long[])parameters.get("groupIds"), search,
+			_parseBoolean((String)parameters.get("showNonindexable")), filter,
+			pagination, sorts);
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+			@Override
+			public boolean isAcceptAllLanguages() {
+				if (ExportImportThreadLocal.isExportInProcess()) {
+					return true;
+				}
+
+				return AcceptLanguage.super.isAcceptAllLanguages();
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			Collection<AssetEntry> assetEntries,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeBiConsumer(
+		UnsafeBiConsumer
+			<Collection<AssetEntry>,
+			 UnsafeFunction<AssetEntry, AssetEntry, Exception>, Exception>
+				contextBatchUnsafeBiConsumer) {
+
+		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<Collection<AssetEntry>, UnsafeConsumer<AssetEntry, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-delivery";
+	}
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource) {
+
+		this.vulcanBatchEngineExportTaskResource =
+			vulcanBatchEngineExportTaskResource;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Sort[] toSorts(String sortString) {
+		if (Validator.isNull(sortString)) {
+			return null;
+		}
+
+		try {
+			SortParser sortParser = sortParserProvider.provide(
+				getEntityModel(Collections.emptyMap()));
+
+			if (sortParser == null) {
+				return null;
+			}
+
+			com.liferay.portal.odata.sort.Sort oDataSort =
+				new com.liferay.portal.odata.sort.Sort(
+					sortParser.parse(sortString));
+
+			List<SortField> sortFields = oDataSort.getSortFields();
+			com.liferay.portal.kernel.search.Sort[] sorts =
+				new com.liferay.portal.kernel.search.Sort[sortFields.size()];
+
+			for (int i = 0; i < sortFields.size(); i++) {
+				SortField sortField = sortFields.get(i);
+
+				sorts[i] = new com.liferay.portal.kernel.search.Sort(
+					sortField.getSortableFieldName(
+						contextAcceptLanguage.getPreferredLocale()),
+					!sortField.isAscending());
+			}
+
+			return sorts;
+		}
+		catch (Exception exception) {
+			_log.error("Invalid sort " + sortString, exception);
+
+			return new com.liferay.portal.kernel.search.Sort[0];
+		}
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<Collection<AssetEntry>,
+		 UnsafeFunction<AssetEntry, AssetEntry, Exception>, Exception>
+			contextBatchUnsafeBiConsumer;
+	protected UnsafeBiConsumer
+		<Collection<AssetEntry>, UnsafeConsumer<AssetEntry, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+	protected VulcanBatchEngineExportTaskResource
+		vulcanBatchEngineExportTaskResource;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseAssetEntryResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:522037246

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -85,6 +85,8 @@ public class OpenAPIResourceImpl {
 
 	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
 		{
+			add(AssetEntryResourceImpl.class);
+
 			add(BlogPostingResourceImpl.class);
 
 			add(BlogPostingImageResourceImpl.class);
@@ -144,4 +146,4 @@ public class OpenAPIResourceImpl {
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:783422324
+// LIFERAY-REST-BUILDER-HASH:-1579558748

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/AssetEntryResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/AssetEntryResourceFactoryImpl.java
@@ -1,0 +1,332 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.resource.v1_0.factory;
+
+import com.liferay.headless.delivery.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.delivery.resource.v1_0.AssetEntryResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-delivery/v1.0/AssetEntry",
+	service = AssetEntryResource.Factory.class
+)
+@Generated("")
+public class AssetEntryResourceFactoryImpl
+	implements AssetEntryResource.Factory {
+
+	@Override
+	public AssetEntryResource.Builder create() {
+		return new AssetEntryResource.Builder() {
+
+			@Override
+			public AssetEntryResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, AssetEntryResource>
+					assetEntryResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_assetEntryResourceProxyProviderFunction;
+
+				return assetEntryResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public AssetEntryResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public AssetEntryResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public AssetEntryResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public AssetEntryResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public AssetEntryResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public AssetEntryResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, AssetEntryResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			AssetEntryResource.class.getClassLoader(),
+			AssetEntryResource.class);
+
+		try {
+			Constructor<AssetEntryResource> constructor =
+				(Constructor<AssetEntryResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		AssetEntryResource assetEntryResource =
+			_componentServiceObjects.getService();
+
+		assetEntryResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		assetEntryResource.setContextCompany(company);
+
+		assetEntryResource.setContextHttpServletRequest(httpServletRequest);
+		assetEntryResource.setContextHttpServletResponse(httpServletResponse);
+		assetEntryResource.setContextUriInfo(uriInfo);
+		assetEntryResource.setContextUser(user);
+		assetEntryResource.setExpressionConvert(_expressionConvert);
+		assetEntryResource.setFilterParserProvider(_filterParserProvider);
+		assetEntryResource.setGroupLocalService(_groupLocalService);
+		assetEntryResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		assetEntryResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		assetEntryResource.setRoleLocalService(_roleLocalService);
+		assetEntryResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(assetEntryResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(assetEntryResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<AssetEntryResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function<InvocationHandler, AssetEntryResource>
+			_assetEntryResourceProxyProviderFunction =
+				_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:354748046

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/asset-entry.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/asset-entry.properties
@@ -1,0 +1,12 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.AssetEntry
+batch.engine.task.item.delegate=true
+batch.planner.export.enabled=true
+batch.planner.import.enabled=false
+entity.class.name=com.liferay.headless.delivery.dto.v1_0.AssetEntry
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/AssetEntryResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/AssetEntryResourceTest.java
@@ -1,0 +1,231 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.blogs.service.BlogsEntryLocalServiceUtil;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.headless.delivery.client.dto.v1_0.AssetEntry;
+import com.liferay.headless.delivery.client.pagination.Page;
+import com.liferay.headless.delivery.client.pagination.Pagination;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luis Ortiz
+ */
+@RunWith(Arquillian.class)
+public class AssetEntryResourceTest extends BaseAssetEntryResourceTestCase {
+
+	@Override
+	@Test
+	public void testGetAssetEntriesPage() throws Exception {
+		super.testGetAssetEntriesPage();
+
+		_testGetAssetEntriesPageWithClassNameIdFilter();
+		_testGetAssetEntriesPageWithClassTypeIdFilter();
+		_testGetAssetEntriesPageWithMultipleClassNameIdsFilter();
+		_testGetAssetEntriesPageWithMultipleGroupIds();
+		_testGetAssetEntriesPageWithStatusFilter();
+	}
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {"assetEntryId", "className", "classPK", "title"};
+	}
+
+	@Override
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[] {"classNameId", "classTypeId", "status"};
+	}
+
+	@Override
+	protected AssetEntry testGetAssetEntriesPage_addAssetEntry(
+			AssetEntry assetEntry)
+		throws Exception {
+
+		BlogsEntry blogsEntry = _addBlogsEntry(testGroup.getGroupId());
+
+		return _toAssetEntry(
+			BlogsEntry.class.getName(), blogsEntry.getEntryId());
+	}
+
+	private BlogsEntry _addBlogsEntry(long groupId) throws Exception {
+		return BlogsEntryLocalServiceUtil.addEntry(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				groupId, TestPropsValues.getUserId()));
+	}
+
+	private boolean _hasClassPK(List<AssetEntry> assetEntries, long classPK) {
+		for (AssetEntry assetEntry : assetEntries) {
+			Long assetEntryClassPK = assetEntry.getClassPK();
+
+			if ((assetEntryClassPK != null) && (assetEntryClassPK == classPK)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private void _testGetAssetEntriesPageWithClassNameIdFilter()
+		throws Exception {
+
+		Long groupId = testGroup.getGroupId();
+
+		BlogsEntry blogsEntry = _addBlogsEntry(groupId);
+		JournalArticle journalArticle = JournalTestUtil.addArticle(groupId, 0);
+
+		String filterString =
+			"classNameId eq " +
+				PortalUtil.getClassNameId(BlogsEntry.class.getName());
+
+		Page<AssetEntry> page = assetEntryResource.getAssetEntriesPage(
+			new Long[] {groupId}, null, null, filterString,
+			Pagination.of(1, 20), null);
+
+		List<AssetEntry> assetEntries = (List<AssetEntry>)page.getItems();
+
+		Assert.assertTrue(_hasClassPK(assetEntries, blogsEntry.getEntryId()));
+		Assert.assertFalse(
+			_hasClassPK(assetEntries, journalArticle.getResourcePrimKey()));
+	}
+
+	private void _testGetAssetEntriesPageWithClassTypeIdFilter()
+		throws Exception {
+
+		Long groupId = testGroup.getGroupId();
+
+		JournalArticle journalArticle1 = JournalTestUtil.addArticle(groupId, 0);
+		JournalArticle journalArticle2 = JournalTestUtil.addArticle(groupId, 0);
+
+		DDMStructure ddmStructure1 = journalArticle1.getDDMStructure();
+		DDMStructure ddmStructure2 = journalArticle2.getDDMStructure();
+
+		Assert.assertNotEquals(ddmStructure1, ddmStructure2);
+
+		String filterString =
+			"classTypeId eq " + ddmStructure1.getStructureId();
+
+		Page<AssetEntry> page = assetEntryResource.getAssetEntriesPage(
+			new Long[] {groupId}, null, null, filterString,
+			Pagination.of(1, 20), null);
+
+		List<AssetEntry> assetEntries = (List<AssetEntry>)page.getItems();
+
+		Assert.assertTrue(
+			_hasClassPK(assetEntries, journalArticle1.getResourcePrimKey()));
+		Assert.assertFalse(
+			_hasClassPK(assetEntries, journalArticle2.getResourcePrimKey()));
+	}
+
+	private void _testGetAssetEntriesPageWithMultipleClassNameIdsFilter()
+		throws Exception {
+
+		Long groupId = testGroup.getGroupId();
+
+		BlogsEntry blogsEntry = _addBlogsEntry(groupId);
+		JournalArticle journalArticle = JournalTestUtil.addArticle(groupId, 0);
+
+		String filterString = StringBundler.concat(
+			"classNameId in (",
+			PortalUtil.getClassNameId(BlogsEntry.class.getName()), ", ",
+			PortalUtil.getClassNameId(JournalArticle.class.getName()), ")");
+
+		Page<AssetEntry> page = assetEntryResource.getAssetEntriesPage(
+			new Long[] {groupId}, null, null, filterString,
+			Pagination.of(1, 20), null);
+
+		List<AssetEntry> assetEntries = (List<AssetEntry>)page.getItems();
+
+		Assert.assertTrue(_hasClassPK(assetEntries, blogsEntry.getEntryId()));
+		Assert.assertTrue(
+			_hasClassPK(assetEntries, journalArticle.getResourcePrimKey()));
+	}
+
+	private void _testGetAssetEntriesPageWithMultipleGroupIds()
+		throws Exception {
+
+		Long groupId1 = testGroup.getGroupId();
+		Long groupId2 = irrelevantGroup.getGroupId();
+
+		BlogsEntry blogsEntry1 = _addBlogsEntry(groupId1);
+		BlogsEntry blogsEntry2 = _addBlogsEntry(groupId2);
+
+		Page<AssetEntry> page = assetEntryResource.getAssetEntriesPage(
+			new Long[] {groupId1, groupId2}, null, null, null,
+			Pagination.of(1, 50), null);
+
+		List<AssetEntry> assetEntries = (List<AssetEntry>)page.getItems();
+
+		Assert.assertTrue(_hasClassPK(assetEntries, blogsEntry1.getEntryId()));
+		Assert.assertTrue(_hasClassPK(assetEntries, blogsEntry2.getEntryId()));
+	}
+
+	private void _testGetAssetEntriesPageWithStatusFilter() throws Exception {
+		Long groupId = testGroup.getGroupId();
+
+		BlogsEntry approvedBlogsEntry = _addBlogsEntry(groupId);
+
+		BlogsEntry draftBlogsEntry = _addBlogsEntry(groupId);
+
+		BlogsEntryLocalServiceUtil.updateStatus(
+			TestPropsValues.getUserId(), draftBlogsEntry.getEntryId(),
+			WorkflowConstants.STATUS_DRAFT,
+			ServiceContextTestUtil.getServiceContext(
+				groupId, TestPropsValues.getUserId()),
+			null);
+
+		Page<AssetEntry> page = assetEntryResource.getAssetEntriesPage(
+			new Long[] {groupId}, null, null, "status eq 'approved'",
+			Pagination.of(1, 50), null);
+
+		List<AssetEntry> assetEntries = (List<AssetEntry>)page.getItems();
+
+		Assert.assertTrue(
+			_hasClassPK(assetEntries, approvedBlogsEntry.getEntryId()));
+		Assert.assertFalse(
+			_hasClassPK(assetEntries, draftBlogsEntry.getEntryId()));
+	}
+
+	private AssetEntry _toAssetEntry(String className, long classPK) {
+		AssetEntry assetEntry = new AssetEntry();
+
+		com.liferay.asset.kernel.model.AssetEntry persistedAssetEntry =
+			_assetEntryLocalService.fetchEntry(className, classPK);
+
+		assetEntry.setAssetEntryId(persistedAssetEntry.getEntryId());
+
+		assetEntry.setClassName(className);
+		assetEntry.setClassPK(classPK);
+		assetEntry.setTitle(
+			persistedAssetEntry.getTitle(LocaleUtil.getDefault()));
+
+		return assetEntry;
+	}
+
+	@Inject
+	private AssetEntryLocalService _assetEntryLocalService;
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseAssetEntryResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseAssetEntryResourceTestCase.java
@@ -1,0 +1,1522 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.delivery.client.dto.v1_0.AssetEntry;
+import com.liferay.headless.delivery.client.dto.v1_0.Field;
+import com.liferay.headless.delivery.client.http.HttpInvoker;
+import com.liferay.headless.delivery.client.pagination.Page;
+import com.liferay.headless.delivery.client.pagination.Pagination;
+import com.liferay.headless.delivery.client.resource.v1_0.AssetEntryResource;
+import com.liferay.headless.delivery.client.serdes.v1_0.AssetEntrySerDes;
+import com.liferay.petra.function.UnsafeTriConsumer;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public abstract class BaseAssetEntryResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_assetEntryResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		assetEntryResource = AssetEntryResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		AssetEntry assetEntry1 = randomAssetEntry();
+
+		String json = objectMapper.writeValueAsString(assetEntry1);
+
+		AssetEntry assetEntry2 = AssetEntrySerDes.toDTO(json);
+
+		Assert.assertTrue(equals(assetEntry1, assetEntry2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		AssetEntry assetEntry = randomAssetEntry();
+
+		String json1 = objectMapper.writeValueAsString(assetEntry);
+		String json2 = AssetEntrySerDes.toJSON(assetEntry);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		AssetEntry assetEntry = randomAssetEntry();
+
+		assetEntry.setAssetType(regex);
+		assetEntry.setClassName(regex);
+		assetEntry.setDescription(regex);
+		assetEntry.setGroupDescriptiveName(regex);
+		assetEntry.setTitle(regex);
+
+		String json = AssetEntrySerDes.toJSON(assetEntry);
+
+		Assert.assertFalse(json.contains(regex));
+
+		assetEntry = AssetEntrySerDes.toDTO(json);
+
+		Assert.assertEquals(regex, assetEntry.getAssetType());
+		Assert.assertEquals(regex, assetEntry.getClassName());
+		Assert.assertEquals(regex, assetEntry.getDescription());
+		Assert.assertEquals(regex, assetEntry.getGroupDescriptiveName());
+		Assert.assertEquals(regex, assetEntry.getTitle());
+	}
+
+	@Test
+	public void testGetAssetEntriesPage() throws Exception {
+		Page<AssetEntry> page = assetEntryResource.getAssetEntriesPage(
+			null, null, null, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		AssetEntry assetEntry1 = testGetAssetEntriesPage_addAssetEntry(
+			randomAssetEntry());
+
+		AssetEntry assetEntry2 = testGetAssetEntriesPage_addAssetEntry(
+			randomAssetEntry());
+
+		page = assetEntryResource.getAssetEntriesPage(
+			null, null, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(assetEntry1, (List<AssetEntry>)page.getItems());
+		assertContains(assetEntry2, (List<AssetEntry>)page.getItems());
+		assertValid(page, testGetAssetEntriesPage_getExpectedActions());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetAssetEntriesPage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetAssetEntriesPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		AssetEntry assetEntry1 = randomAssetEntry();
+
+		assetEntry1 = testGetAssetEntriesPage_addAssetEntry(assetEntry1);
+
+		for (EntityField entityField : entityFields) {
+			Page<AssetEntry> page = assetEntryResource.getAssetEntriesPage(
+				null, null, null,
+				getFilterString(entityField, "between", assetEntry1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(assetEntry1),
+				(List<AssetEntry>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetAssetEntriesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		testGetAssetEntriesPageWithFilter("eq", EntityField.Type.DOUBLE);
+	}
+
+	@Test
+	public void testGetAssetEntriesPageWithFilterStringContains()
+		throws Exception {
+
+		testGetAssetEntriesPageWithFilter("contains", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetAssetEntriesPageWithFilterStringEquals()
+		throws Exception {
+
+		testGetAssetEntriesPageWithFilter("eq", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetAssetEntriesPageWithFilterStringStartsWith()
+		throws Exception {
+
+		testGetAssetEntriesPageWithFilter(
+			"startswith", EntityField.Type.STRING);
+	}
+
+	protected void testGetAssetEntriesPageWithFilter(
+			String operator, EntityField.Type type)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		AssetEntry assetEntry1 = testGetAssetEntriesPage_addAssetEntry(
+			randomAssetEntry());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		AssetEntry assetEntry2 = testGetAssetEntriesPage_addAssetEntry(
+			randomAssetEntry());
+
+		for (EntityField entityField : entityFields) {
+			Page<AssetEntry> page = assetEntryResource.getAssetEntriesPage(
+				null, null, null,
+				getFilterString(entityField, operator, assetEntry1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(assetEntry1),
+				(List<AssetEntry>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetAssetEntriesPageWithPagination() throws Exception {
+		Page<AssetEntry> assetEntriesPage =
+			assetEntryResource.getAssetEntriesPage(
+				null, null, null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(
+			assetEntriesPage.getTotalCount());
+
+		AssetEntry assetEntry1 = testGetAssetEntriesPage_addAssetEntry(
+			randomAssetEntry());
+
+		AssetEntry assetEntry2 = testGetAssetEntriesPage_addAssetEntry(
+			randomAssetEntry());
+
+		AssetEntry assetEntry3 = testGetAssetEntriesPage_addAssetEntry(
+			randomAssetEntry());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<AssetEntry> page1 = assetEntryResource.getAssetEntriesPage(
+				null, null, null, null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+					pageSizeLimit),
+				null);
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(assetEntry1, (List<AssetEntry>)page1.getItems());
+
+			Page<AssetEntry> page2 = assetEntryResource.getAssetEntriesPage(
+				null, null, null, null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+					pageSizeLimit),
+				null);
+
+			assertContains(assetEntry2, (List<AssetEntry>)page2.getItems());
+
+			Page<AssetEntry> page3 = assetEntryResource.getAssetEntriesPage(
+				null, null, null, null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+					pageSizeLimit),
+				null);
+
+			assertContains(assetEntry3, (List<AssetEntry>)page3.getItems());
+		}
+		else {
+			Page<AssetEntry> page1 = assetEntryResource.getAssetEntriesPage(
+				null, null, null, null, Pagination.of(1, totalCount + 2), null);
+
+			List<AssetEntry> assetEntries1 = (List<AssetEntry>)page1.getItems();
+
+			Assert.assertEquals(
+				assetEntries1.toString(), totalCount + 2, assetEntries1.size());
+
+			Page<AssetEntry> page2 = assetEntryResource.getAssetEntriesPage(
+				null, null, null, null, Pagination.of(2, totalCount + 2), null);
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<AssetEntry> assetEntries2 = (List<AssetEntry>)page2.getItems();
+
+			Assert.assertEquals(
+				assetEntries2.toString(), 1, assetEntries2.size());
+
+			Page<AssetEntry> page3 = assetEntryResource.getAssetEntriesPage(
+				null, null, null, null, Pagination.of(1, (int)totalCount + 3),
+				null);
+
+			assertContains(assetEntry1, (List<AssetEntry>)page3.getItems());
+			assertContains(assetEntry2, (List<AssetEntry>)page3.getItems());
+			assertContains(assetEntry3, (List<AssetEntry>)page3.getItems());
+		}
+	}
+
+	@Test
+	public void testGetAssetEntriesPageWithSortDateTime() throws Exception {
+		testGetAssetEntriesPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, assetEntry1, assetEntry2) -> {
+				BeanTestUtil.setProperty(
+					assetEntry1, entityField.getName(),
+					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
+			});
+	}
+
+	@Test
+	public void testGetAssetEntriesPageWithSortDouble() throws Exception {
+		testGetAssetEntriesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, assetEntry1, assetEntry2) -> {
+				BeanTestUtil.setProperty(
+					assetEntry1, entityField.getName(), 0.1);
+				BeanTestUtil.setProperty(
+					assetEntry2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
+	public void testGetAssetEntriesPageWithSortInteger() throws Exception {
+		testGetAssetEntriesPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, assetEntry1, assetEntry2) -> {
+				BeanTestUtil.setProperty(assetEntry1, entityField.getName(), 0);
+				BeanTestUtil.setProperty(assetEntry2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetAssetEntriesPageWithSortString() throws Exception {
+		testGetAssetEntriesPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, assetEntry1, assetEntry2) -> {
+				Class<?> clazz = assetEntry1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanTestUtil.setProperty(
+						assetEntry1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanTestUtil.setProperty(
+						assetEntry2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanTestUtil.setProperty(
+						assetEntry1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanTestUtil.setProperty(
+						assetEntry2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanTestUtil.setProperty(
+						assetEntry1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanTestUtil.setProperty(
+						assetEntry2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetAssetEntriesPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer<EntityField, AssetEntry, AssetEntry, Exception>
+				unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		AssetEntry assetEntry1 = randomAssetEntry();
+		AssetEntry assetEntry2 = randomAssetEntry();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(entityField, assetEntry1, assetEntry2);
+		}
+
+		assetEntry1 = testGetAssetEntriesPage_addAssetEntry(assetEntry1);
+
+		assetEntry2 = testGetAssetEntriesPage_addAssetEntry(assetEntry2);
+
+		Page<AssetEntry> page = assetEntryResource.getAssetEntriesPage(
+			null, null, null, null, null, null);
+
+		for (EntityField entityField : entityFields) {
+			Page<AssetEntry> ascPage = assetEntryResource.getAssetEntriesPage(
+				null, null, null, null,
+				Pagination.of(1, (int)page.getTotalCount() + 1),
+				entityField.getName() + ":asc");
+
+			assertContains(assetEntry1, (List<AssetEntry>)ascPage.getItems());
+			assertContains(assetEntry2, (List<AssetEntry>)ascPage.getItems());
+
+			Page<AssetEntry> descPage = assetEntryResource.getAssetEntriesPage(
+				null, null, null, null,
+				Pagination.of(1, (int)page.getTotalCount() + 1),
+				entityField.getName() + ":desc");
+
+			assertContains(assetEntry2, (List<AssetEntry>)descPage.getItems());
+			assertContains(assetEntry1, (List<AssetEntry>)descPage.getItems());
+		}
+	}
+
+	protected AssetEntry testGetAssetEntriesPage_addAssetEntry(
+			AssetEntry assetEntry)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testBatchEngineDeleteImportTask() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	protected void assertContains(
+		AssetEntry assetEntry, List<AssetEntry> assetEntries) {
+
+		boolean contains = false;
+
+		for (AssetEntry item : assetEntries) {
+			if (equals(assetEntry, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			assetEntries + " does not contain " + assetEntry, contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		AssetEntry assetEntry1, AssetEntry assetEntry2) {
+
+		Assert.assertTrue(
+			assetEntry1 + " does not equal " + assetEntry2,
+			equals(assetEntry1, assetEntry2));
+	}
+
+	protected void assertEquals(
+		List<AssetEntry> assetEntries1, List<AssetEntry> assetEntries2) {
+
+		Assert.assertEquals(assetEntries1.size(), assetEntries2.size());
+
+		for (int i = 0; i < assetEntries1.size(); i++) {
+			AssetEntry assetEntry1 = assetEntries1.get(i);
+			AssetEntry assetEntry2 = assetEntries2.get(i);
+
+			assertEquals(assetEntry1, assetEntry2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<AssetEntry> assetEntries1, List<AssetEntry> assetEntries2) {
+
+		Assert.assertEquals(assetEntries1.size(), assetEntries2.size());
+
+		for (AssetEntry assetEntry1 : assetEntries1) {
+			boolean contains = false;
+
+			for (AssetEntry assetEntry2 : assetEntries2) {
+				if (equals(assetEntry1, assetEntry2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				assetEntries2 + " does not contain " + assetEntry1, contains);
+		}
+	}
+
+	protected void assertValid(AssetEntry assetEntry) throws Exception {
+		boolean valid = true;
+
+		if (assetEntry.getAssetEntryId() == null) {
+			valid = false;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("assetEntryId", additionalAssertFieldName)) {
+				if (assetEntry.getAssetEntryId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("assetType", additionalAssertFieldName)) {
+				if (assetEntry.getAssetType() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("className", additionalAssertFieldName)) {
+				if (assetEntry.getClassName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("classNameId", additionalAssertFieldName)) {
+				if (assetEntry.getClassNameId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("classPK", additionalAssertFieldName)) {
+				if (assetEntry.getClassPK() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("description", additionalAssertFieldName)) {
+				if (assetEntry.getDescription() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"groupDescriptiveName", additionalAssertFieldName)) {
+
+				if (assetEntry.getGroupDescriptiveName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (assetEntry.getTitle() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<AssetEntry> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<AssetEntry> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<AssetEntry> assetEntries = page.getItems();
+
+		int size = assetEntries.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		graphQLFields.add(new GraphQLField("assetEntryId"));
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.delivery.dto.v1_0.AssetEntry.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(AssetEntry assetEntry1, AssetEntry assetEntry2) {
+		if (assetEntry1 == assetEntry2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("assetEntryId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetEntry1.getAssetEntryId(),
+						assetEntry2.getAssetEntryId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("assetType", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetEntry1.getAssetType(),
+						assetEntry2.getAssetType())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("className", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetEntry1.getClassName(),
+						assetEntry2.getClassName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("classNameId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetEntry1.getClassNameId(),
+						assetEntry2.getClassNameId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("classPK", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetEntry1.getClassPK(), assetEntry2.getClassPK())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("description", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetEntry1.getDescription(),
+						assetEntry2.getDescription())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"groupDescriptiveName", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						assetEntry1.getGroupDescriptiveName(),
+						assetEntry2.getGroupDescriptiveName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetEntry1.getTitle(), assetEntry2.getTitle())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_assetEntryResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_assetEntryResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator, AssetEntry assetEntry) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("assetEntryId")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("assetType")) {
+			Object object = assetEntry.getAssetType();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("className")) {
+			Object object = assetEntry.getClassName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("classNameId")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("classPK")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("description")) {
+			Object object = assetEntry.getDescription();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("groupDescriptiveName")) {
+			Object object = assetEntry.getGroupDescriptiveName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("title")) {
+			Object object = assetEntry.getTitle();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected AssetEntry randomAssetEntry() throws Exception {
+		return new AssetEntry() {
+			{
+				assetEntryId = RandomTestUtil.randomLong();
+				assetType = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				className = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				classNameId = RandomTestUtil.randomLong();
+				classPK = RandomTestUtil.randomLong();
+				description = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				groupDescriptiveName = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected AssetEntry randomIrrelevantAssetEntry() throws Exception {
+		AssetEntry randomIrrelevantAssetEntry = randomAssetEntry();
+
+		return randomIrrelevantAssetEntry;
+	}
+
+	protected AssetEntry randomPatchAssetEntry() throws Exception {
+		return randomAssetEntry();
+	}
+
+	protected AssetEntryResource assetEntryResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseAssetEntryResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.headless.delivery.resource.v1_0.AssetEntryResource
+		_assetEntryResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-2131418963

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -505,6 +505,24 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 	@Override
 	public Hits search(
+		long companyId, long[] groupIds, long userId, long[] classNameIds,
+		long classTypeId, String keywords, boolean showNonindexable,
+		int[] statuses, int start, int end, Sort[] sorts) {
+
+		try {
+			SearchContext searchContext = buildSearchContext(
+				companyId, groupIds, userId, classTypeId, keywords, null, null,
+				showNonindexable, statuses, false, start, end, sorts);
+
+			return doSearch(classNameIds, searchContext);
+		}
+		catch (Exception exception) {
+			throw new SystemException(exception);
+		}
+	}
+
+	@Override
+	public Hits search(
 		long companyId, long[] groupIds, long userId, String className,
 		long classTypeId, String keywords, boolean showNonindexable, int status,
 		int start, int end) {
@@ -543,6 +561,24 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 			SearchContext searchContext = buildSearchContext(
 				companyId, groupIds, userId, classTypeId, keywords, null, null,
 				showNonindexable, statuses, false, start, end, sort);
+
+			return doSearch(companyId, className, searchContext);
+		}
+		catch (Exception exception) {
+			throw new SystemException(exception);
+		}
+	}
+
+	@Override
+	public Hits search(
+		long companyId, long[] groupIds, long userId, String className,
+		long classTypeId, String keywords, boolean showNonindexable,
+		int[] statuses, int start, int end, Sort[] sorts) {
+
+		try {
+			SearchContext searchContext = buildSearchContext(
+				companyId, groupIds, userId, classTypeId, keywords, null, null,
+				showNonindexable, statuses, false, start, end, sorts);
 
 			return doSearch(companyId, className, searchContext);
 		}
@@ -1059,13 +1095,24 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		return buildSearchContext(
 			companyId, groupIds, userId, classTypeId, assetCategoryIds,
 			assetTagNames, showNonindexable, statuses, andSearch, start, end,
-			null);
+			(Sort)null);
 	}
 
 	protected SearchContext buildSearchContext(
 		long companyId, long[] groupIds, long userId, long classTypeId,
 		String assetCategoryIds, String assetTagNames, boolean showNonindexable,
 		int[] statuses, boolean andSearch, int start, int end, Sort sort) {
+
+		return buildSearchContext(
+			companyId, groupIds, userId, classTypeId, assetCategoryIds,
+			assetTagNames, showNonindexable, statuses, andSearch, start, end,
+			(sort == null) ? null : new Sort[] {sort});
+	}
+
+	protected SearchContext buildSearchContext(
+		long companyId, long[] groupIds, long userId, long classTypeId,
+		String assetCategoryIds, String assetTagNames, boolean showNonindexable,
+		int[] statuses, boolean andSearch, int start, int end, Sort[] sorts) {
 
 		SearchContext searchContext = new SearchContext();
 
@@ -1088,7 +1135,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		searchContext.setCompanyId(companyId);
 		searchContext.setEnd(end);
 		searchContext.setGroupIds(groupIds);
-		searchContext.setSorts(sort);
+		searchContext.setSorts(sorts);
 		searchContext.setStart(start);
 		searchContext.setUserId(userId);
 
@@ -1120,6 +1167,22 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 			companyId, groupIds, userId, classTypeId, assetCategoryIds,
 			assetTagNames, showNonindexable, statuses, andSearch, start, end,
 			sort);
+
+		searchContext.setKeywords(keywords);
+
+		return searchContext;
+	}
+
+	protected SearchContext buildSearchContext(
+		long companyId, long[] groupIds, long userId, long classTypeId,
+		String keywords, String assetCategoryIds, String assetTagNames,
+		boolean showNonindexable, int[] statuses, boolean andSearch, int start,
+		int end, Sort[] sorts) {
+
+		SearchContext searchContext = buildSearchContext(
+			companyId, groupIds, userId, classTypeId, assetCategoryIds,
+			assetTagNames, showNonindexable, statuses, andSearch, start, end,
+			sorts);
 
 		searchContext.setKeywords(keywords);
 

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalService.java
@@ -428,6 +428,12 @@ public interface AssetEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Hits search(
+		long companyId, long[] groupIds, long userId, long[] classNameIds,
+		long classTypeId, String keywords, boolean showNonindexable,
+		int[] statuses, int start, int end, Sort[] sorts);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Hits search(
 		long companyId, long[] groupIds, long userId, String className,
 		long classTypeId, String keywords, boolean showNonindexable, int status,
 		int start, int end);
@@ -443,6 +449,12 @@ public interface AssetEntryLocalService
 		long companyId, long[] groupIds, long userId, String className,
 		long classTypeId, String keywords, boolean showNonindexable,
 		int[] statuses, int start, int end, Sort sort);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Hits search(
+		long companyId, long[] groupIds, long userId, String className,
+		long classTypeId, String keywords, boolean showNonindexable,
+		int[] statuses, int start, int end, Sort[] sorts);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Hits search(
@@ -594,4 +606,4 @@ public interface AssetEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1072980987
+// LIFERAY-SERVICE-BUILDER-HASH:1816903266

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceUtil.java
@@ -544,6 +544,17 @@ public class AssetEntryLocalServiceUtil {
 	}
 
 	public static com.liferay.portal.kernel.search.Hits search(
+		long companyId, long[] groupIds, long userId, long[] classNameIds,
+		long classTypeId, String keywords, boolean showNonindexable,
+		int[] statuses, int start, int end,
+		com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return getService().search(
+			companyId, groupIds, userId, classNameIds, classTypeId, keywords,
+			showNonindexable, statuses, start, end, sorts);
+	}
+
+	public static com.liferay.portal.kernel.search.Hits search(
 		long companyId, long[] groupIds, long userId, String className,
 		long classTypeId, String keywords, boolean showNonindexable, int status,
 		int start, int end) {
@@ -572,6 +583,17 @@ public class AssetEntryLocalServiceUtil {
 		return getService().search(
 			companyId, groupIds, userId, className, classTypeId, keywords,
 			showNonindexable, statuses, start, end, sort);
+	}
+
+	public static com.liferay.portal.kernel.search.Hits search(
+		long companyId, long[] groupIds, long userId, String className,
+		long classTypeId, String keywords, boolean showNonindexable,
+		int[] statuses, int start, int end,
+		com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return getService().search(
+			companyId, groupIds, userId, className, classTypeId, keywords,
+			showNonindexable, statuses, start, end, sorts);
 	}
 
 	public static com.liferay.portal.kernel.search.Hits search(
@@ -814,4 +836,4 @@ public class AssetEntryLocalServiceUtil {
 	private static volatile AssetEntryLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1773109093
+// LIFERAY-SERVICE-BUILDER-HASH:1660055984

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceWrapper.java
@@ -624,6 +624,18 @@ public class AssetEntryLocalServiceWrapper
 
 	@Override
 	public com.liferay.portal.kernel.search.Hits search(
+		long companyId, long[] groupIds, long userId, long[] classNameIds,
+		long classTypeId, String keywords, boolean showNonindexable,
+		int[] statuses, int start, int end,
+		com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return _assetEntryLocalService.search(
+			companyId, groupIds, userId, classNameIds, classTypeId, keywords,
+			showNonindexable, statuses, start, end, sorts);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Hits search(
 		long companyId, long[] groupIds, long userId, String className,
 		long classTypeId, String keywords, boolean showNonindexable, int status,
 		int start, int end) {
@@ -654,6 +666,18 @@ public class AssetEntryLocalServiceWrapper
 		return _assetEntryLocalService.search(
 			companyId, groupIds, userId, className, classTypeId, keywords,
 			showNonindexable, statuses, start, end, sort);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Hits search(
+		long companyId, long[] groupIds, long userId, String className,
+		long classTypeId, String keywords, boolean showNonindexable,
+		int[] statuses, int start, int end,
+		com.liferay.portal.kernel.search.Sort[] sorts) {
+
+		return _assetEntryLocalService.search(
+			companyId, groupIds, userId, className, classTypeId, keywords,
+			showNonindexable, statuses, start, end, sorts);
 	}
 
 	@Override
@@ -947,4 +971,4 @@ public class AssetEntryLocalServiceWrapper
 	private AssetEntryLocalService _assetEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:300908687
+// LIFERAY-SERVICE-BUILDER-HASH:-1238175294

--- a/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 17.0.0
+version 17.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88506

## What Is Being Fixed

The React Item Selector needs a single headless endpoint to search asset entries across multiple class names, with filtering, scoping, pagination, and sorting — capabilities the legacy asset browser item selector provided only through server-side portlet code, with no REST equivalent.

## How It Is Being Fixed

A new `GET /o/headless-delivery/v1.0/asset-entries` endpoint is added through REST Builder. It searches every registered asset type via `AssetSearcherFactoryUtil`, scoping to the union of the supplied `groupIds` (or every group the user can read when omitted). Entity-level filters — `classNameId`, `classTypeId`, and `status` — are exposed through OData on `AssetEntryEntityModel`, with value-translation functions mapping the numeric class name id to the indexed class name and the workflow status label to its constant. Result rows are converted by a dedicated `AssetEntryDTOConverter` that mirrors the legacy item descriptor's asset-type and group-descriptive-name resolution. To honor multiple sort fields, a `Sort[]` overload was added to `AssetEntryLocalService.search`, with the existing single-`Sort` methods forwarding to it.
